### PR TITLE
Add v0.5 charger-priority mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ a persistent brushing log.
 
 - [The problem](#the-problem)
 - [How it works](#how-it-works)
+- [Connection modes](#connection-modes)
 - [How this differs from the official integration](#how-this-differs-from-the-official-integration)
 - [Entities](#entities)
 - [Tested with](#tested-with)
@@ -57,18 +58,70 @@ exactly like the official integration. Zero cost while the brush sleeps
 on its charger, and it keeps state, battery and pressure up to date
 between sessions.
 
-**Active layer.** As soon as an advertisement reports an awake state,
-the integration opens a GATT connection — through any connectable
+**Active layer.** Opens a GATT connection — through any connectable
 Bluetooth path, including ESPHome Bluetooth proxies with active
-connections enabled — and subscribes to the live notification
-characteristics. The 1 Hz brushing timer, pressure, quadrant and mode
-flow straight into the entities.
+connections enabled — either held continuously for live 1 Hz data or
+opened briefly after each session, depending on the configured
+[connection mode](#connection-modes).
 
-**Polite by design.** The brush accepts a single client. If the
-connection cannot be won, typically because the Oral-B phone app or an
-iO Sense charger holds it, the integration falls back to passive mode
-rather than fighting for the device. When the brush returns to charging
-or sleep, the connection is released promptly so other clients can sync.
+**One connection slot.** The brush accepts exactly one BLE client at a
+time — and it stops advertising entirely while that slot is taken.
+Whoever holds the slot gets everything (live notifications, the session
+record); everyone else gets silence. This was established empirically
+in July 2026 on an iO Series 10 with an iO Sense charger: with Home
+Assistant holding the connection, live data streamed into Home
+Assistant perfectly — and the iO Sense display stayed dark. With the
+charger holding it, the display worked — and the brush was
+radio-silent to everyone else until the session was over. This is a
+firmware property of the brush, not something any integration can work
+around, and it forces the trade-off described in the next section.
+
+## Connection modes
+
+Three parties want the brush's single connection slot: the iO Sense
+charger (for its lights and countdown display), the Oral-B phone app,
+and Home Assistant. Only one of them can have it during a brushing
+session. Because no software can remove that constraint, who wins is a
+configuration option: *Settings → Devices & Services → Oral-B Live →
+Configure*. Switching takes effect immediately.
+
+### Charger priority (default)
+
+Home Assistant never competes for the slot. During a session the
+charger (or the app) connects as designed, so the iO Sense lights and
+timer behave exactly as they do out of the box. When the brush is
+docked or idle again after a session — it frees the slot and resumes
+advertising within about 30 seconds — Home Assistant connects for a
+few seconds, reads the brush's own **last-session record** (see
+[Protocol notes](#last-session-record-ff29)), the battery level and
+the state, then disconnects.
+
+What you give up: the timer, pressure and quadrant entities do not
+update *during* the session, because the brush is silent on the air
+while the charger holds the slot. The session appears in Home
+Assistant roughly a minute after you finish brushing — timed, dated
+and measured by the brush itself, so nothing is lost if an
+advertisement is missed.
+
+What you keep: a complete brushing log (start time, duration, mode),
+battery tracking, and a fully functional charger and phone app.
+
+If several sessions happen while Home Assistant is down or out of
+range, only the most recent one is recovered — the record on the brush
+holds a single session.
+
+### Live
+
+The original behaviour (v0.4 and earlier). Home Assistant seizes the
+slot whenever it is free — most reliably while the brush is docked —
+and holds it. All entities update live at 1 Hz during brushing: timer,
+pressure, quadrant, mode. Sessions are recorded from the live stream.
+
+What you give up: while Home Assistant holds the slot, the iO Sense
+display does not work and the phone app cannot sync. The brush also
+drops idle clients after about 30 seconds of its own accord, so the
+integration reconnects continuously in the background — this is
+normal and visible as brief `live_connection` flaps while docked.
 
 ## How this differs from the official integration
 
@@ -107,26 +160,33 @@ connection.
 
 This integration keeps the passive listening and adds that connection.
 
+The "Oral-B Live" column below describes **live** mode; in
+charger-priority mode the in-session rows are traded for a
+post-session sync — see [Connection modes](#connection-modes).
+
 | | Official `oralb` | Oral-B Live |
 | --- | --- | --- |
-| Data source | Advertisements only | Advertisements plus GATT notifications |
-| Connection | Never connects (battery uses a poll) | Connects while the brush is awake, releases on charge/sleep |
-| Live timer on recent iO firmware | Stays at 0, jumps at the end | Counts up at 1 Hz while brushing |
-| Live pressure during a session | Frozen at its pre-session value | `low` / `normal` / `high`, live from `ff0b` |
-| Live quadrant during a session | Frozen | Advances as the brush paces them |
-| A missed summary advertisement | Session lost entirely | Session still recorded from the live stream |
+| Data source | Advertisements only | Advertisements plus GATT (notifications or post-session reads) |
+| Connection | Never connects (battery uses a poll) | Configurable: held live connection, or a few seconds after each session |
+| Live timer on recent iO firmware | Stays at 0, jumps at the end | Counts up at 1 Hz while brushing (live mode) |
+| Live pressure during a session | Frozen at its pre-session value | `low` / `normal` / `high`, live from `ff0b` (live mode) |
+| Live quadrant during a session | Frozen | Advances as the brush paces them (live mode) |
+| A missed summary advertisement | Session lost entirely | Session still recorded: live stream, or the brush's own `ff29` record |
 | Brushing log | None | Last session, duration, sessions today, kept across restarts |
 | Number of sectors | From advertisement | Read from the brush's quadrant configuration |
-| Battery | Active poll (can stall updates on this firmware) | Read once per connection |
-| Cost | None | One Bluetooth connection slot while the brush is awake |
-| Competes with the phone app | No | Yes — falls back to passive when the app wins |
+| Battery | Active poll (can stall updates on this firmware) | Read on connect / each sync |
+| Cost | None | One Bluetooth connection slot (held, or briefly per sync) |
+| iO Sense charger display | Works | Works in charger-priority mode; disabled in live mode |
+| Competes with the phone app | No | Live mode: yes. Charger priority: no |
 
 Practical trade-offs worth knowing before switching:
 
-- The brush accepts one client. While this integration is connected, the
-  Oral-B app and an iO Sense charger cannot sync.
-- Holding a connection uses more brush battery than passive listening.
-  Lower `IDLE_DISCONNECT_SECONDS` in `const.py` if that matters to you.
+- The brush accepts one client at a time. In live mode, while this
+  integration is connected, the Oral-B app and the iO Sense charger
+  cannot connect at all — this is why charger-priority mode exists and
+  is the default.
+- Holding a connection (live mode) uses more brush battery than
+  passive listening or brief per-session syncs.
 - Entity IDs differ from the official integration, so dashboard cards
   need repointing after switching.
 - Everything here was worked out on one brush. On other models the
@@ -140,29 +200,36 @@ dashboards and toothbrush cards keep working.
 | Entity | Description |
 | --- | --- |
 | Toothbrush state | `idle`, `running`, `charging`, `selection_menu`, `session_summary`, `post_brushing_summary`, ... |
-| Time | Session duration in seconds. Updates at 1 Hz while connected. |
+| Time | Session duration in seconds. Updates at 1 Hz while connected (live mode). |
 | Sector | Current quadrant (`sector_0` ... `sector_3`, or `no_sector`) |
 | Number of sectors | Read from the brush's quadrant time configuration |
 | Mode | `daily_clean`, `sensitive`, `gum_care`, `whiten`, `intense`, ... |
 | Pressure | `low` / `normal` / `high`, live while connected |
-| Battery | Percentage, read on connect |
+| Battery | Percentage, read on connect / each sync |
 | Last session | Timestamp of the last completed session |
 | Last session duration | Length of that session, in seconds |
 | Sessions today | Number of sessions today, resets at midnight |
 
-The state entity also exposes `live_connection`, `rssi`, `state_raw` and
-`mode_raw` as attributes, which is useful when diagnosing whether a
-session was captured actively or passively.
+In charger-priority mode the in-session entities (time, pressure,
+sector) update only from advertisements and the post-session sync; in
+live mode they stream at 1 Hz. See
+[Connection modes](#connection-modes).
+
+The state entity also exposes `live_connection`, `connection_mode`,
+`rssi`, `state_raw` and `mode_raw` as attributes, which is useful when
+diagnosing how a session was captured.
 
 ### Brushing log
 
-The brush does not hand over its stored history, so the integration
-builds its own. When a session ends, **Last session** records the start
-time with `duration_seconds`, `mode`, `quadrants_covered` and
-`high_pressure_events` as attributes. Because it is a proper timestamp
-sensor, Home Assistant's recorder keeps the history automatically: a
-history graph on **Last session duration** is a complete brushing log
-that accumulates from installation onwards.
+When a session ends, **Last session** records the start time with
+`duration_seconds`, `mode`, `quadrants_covered` and
+`high_pressure_events` as attributes. In live mode these come from the
+live stream; in charger-priority mode the start time, duration and
+mode come from the brush's own last-session record (quadrant and
+pressure detail are not available in that record). Because it is a
+proper timestamp sensor, Home Assistant's recorder keeps the history
+automatically: a history graph on **Last session duration** is a
+complete brushing log that accumulates from installation onwards.
 
 Session values are restored across restarts and stay readable while the
 brush is out of range. Sessions with no recorded duration (the motor
@@ -219,6 +286,11 @@ Copy `custom_components/oralb_live` into your Home Assistant
    automatically; confirm the discovered device.
 3. Alternatively add it manually via *Settings, Devices & Services, Add
    integration, Oral-B Live*.
+4. Pick a **connection mode** via *Configure* on the integration entry
+   — see [Connection modes](#connection-modes). The default, charger
+   priority, keeps the iO Sense charger display and the phone app
+   working; switch to live mode if you want in-session 1 Hz data in
+   Home Assistant instead.
 
 ## Dashboard
 
@@ -295,21 +367,30 @@ and will miss advertisements from a brush that only speaks occasionally.
 
 ## Known limitations
 
+**One client at a time.** The brush's single BLE connection slot is the
+defining constraint of this integration; see
+[Connection modes](#connection-modes) for why the trade-off cannot be
+engineered away. In live mode the charger display and phone app lose;
+in charger-priority mode Home Assistant deliberately loses during the
+session and catches up from the brush's own record afterwards. There
+is no configuration in which both stream live simultaneously.
+
+**Charger-priority mode recovers one session at a time.** The brush's
+last-session record holds exactly one session. If Home Assistant is
+down or out of range across several sessions, only the most recent is
+recovered on the next sync.
+
 **Quadrant changes are paced by the brush.** The brush emits a quadrant
 notification only when the sector actually changes, typically every 30
 seconds depending on its configuration. The quadrant is the brush's own
 pacer telling you where to brush next, not a detection of where the
 brush actually is. Short sessions may show only one quadrant.
 
-**The phone app wins connection races.** With Bluetooth enabled and the
-Oral-B app paired, the app may claim the brush first. The integration
-then reports passive data only, which on recent firmware can mean just
-the end-of-session summary.
-
-**Stored session history is not available.** The brush's own records are
-not exposed to unauthenticated clients; see
-[Protocol notes](#protocol-notes). The integration builds its own log
-from live sessions instead.
+**Full stored history is not available.** The brush exposes its most
+recent session in `ff29` (used by charger-priority mode), but the
+deeper multi-session history the phone app shows requires control-
+channel commands and is deliberately not attempted; see
+[Protocol notes](#protocol-notes).
 
 ## Protocol notes
 
@@ -317,6 +398,29 @@ Findings from GATT reconnaissance of an Oral-B iO Series 10 (model ID
 `0x36`, protocol version 8), July 2026, cross-checked against
 MatrixEditor/oralb-io. Documented here so others do not have to repeat
 the work.
+
+### One connection slot, and what it does to advertising
+
+The brush accepts a single BLE client. While that slot is held — by
+the iO Sense charger, the phone app, or Home Assistant — the brush
+**stops advertising entirely**, so other clients cannot even discover
+it, let alone connect (connection attempts fail with device-not-found
+or time out). When the slot is free the brush advertises continuously
+in idle/charging states with `kCBAdvDataIsConnectable` set, and a
+pending connection completes in well under a second.
+
+Two behaviours follow that are worth knowing:
+
+- **The brush sheds idle clients after ~30 seconds.** A client that is
+  connected but receiving no notifications (brush idle on the charger)
+  is disconnected by the brush almost exactly 30 s after activity
+  stops. Reconnection is immediate. A held "permanent" connection is
+  therefore really a connect/drop/reconnect cycle while docked.
+- **A connection made while docked survives a session.** If a client
+  wins the slot while the brush is charging, picking the brush up and
+  brushing does not evict it: the client receives the full state
+  transitions, the 1 Hz timer, ~30 Hz pressure and quadrant
+  notifications for the whole session. This is what live mode does.
 
 ### Vendor service `a0f0ff00-5047-4d53-8208-4f72616c2d42`
 
@@ -334,16 +438,16 @@ the work.
 | `ff0b` | notify, read | **Pressure** (0 low, 1 normal, 2 high) |
 | `ff0c` | read, write, notify | Cache — requires authentication |
 | `ff0d` | notify, read | Motion sensor data, roughly 30 Hz |
+| `ff29` | read | **Last completed session record** (see below) |
 
 Configuration service `a0f0ff20-...`:
 
 | Characteristic | Access | Content |
 | --- | --- | --- |
 | `ff21` | read, write, notify | Control channel (commands) |
-| `ff22` | read, write | Real-time clock, seconds since 2000-01-01 |
+| `ff22` | read, write | Real-time clock, seconds on the brush's own epoch |
 | `ff25` | read, write | Available brushing modes |
 | `ff26` | read, write | Quadrant times, seconds per sector |
-| `ff29` | read | Session data |
 
 Service `a0f0ff80-...` is the over-the-air firmware update channel
 (`ff81` OTA command, `ff82` OTA payload) and is not used by this
@@ -363,16 +467,47 @@ plausibly go. Reading it during hard brushing returns a constant
 `00 00 00 00`, which is easy to misinterpret as a broken pressure
 sensor.
 
-### Stored session history
+### Last-session record (`ff29`)
 
-`ff29` holds a session record with a timestamp (seconds since
-2000-01-01) but does not update on its own: it stayed byte-identical
-across several completed sessions, so it appears to be a buffer the
-control channel fills on request. `ff0c` is annotated as requiring
-authentication, and `ff2c` (dashboard config) is absent on this
-firmware. Retrieving history therefore needs writes to the `ff21`
-control channel, whose command set also contains a factory reset, so it
-is deliberately not attempted here.
+An earlier revision of these notes claimed `ff29` never changed and
+needed control-channel commands to fill. That was wrong: on this
+firmware it updates within seconds of every completed session, and
+anonymous clients can read it freely. Observed layout, 23 bytes,
+little-endian:
+
+| Offset | Example | Content |
+| --- | --- | --- |
+| 0–3 | `c2 1e f5 31` | Session start, seconds on the brush clock |
+| 4–5 | `49 01` | Session counter (tentative; 329, appears to increment per session) |
+| 6–7 | `78 00` | Target duration, seconds (120) |
+| 8–9 | `3c 00` | **Session duration, seconds** |
+| 10–11 | `14 00` | Pressure-related count (tentative) |
+| 12–13 | `1e 00` | Per-quadrant time, seconds (matches `ff26`) |
+| 14–18 | `12 1f 0a 01 01` | Unknown |
+| 19 | `04` | Brushing mode |
+| 20 | `5f` | Battery percent at session end |
+| 21–22 | `00 00` | Unknown |
+
+The example is a real 60-second session in `intense` mode at 95%
+battery. Verification of the timestamp field: `ff22` (the RTC, same
+epoch) read 63 seconds after the session started returned exactly the
+record's timestamp plus 63.
+
+**The brush clock drifts.** On the tested unit it ran about eight days
+ahead of wall time — it is presumably only disciplined when the phone
+app syncs it. Do not convert the record timestamp to absolute time
+directly. Instead read `ff22` in the same connection and compute
+`wall_start = now − (rtc − record_timestamp)`, which cancels the drift
+entirely. This is what charger-priority mode does; the raw timestamp
+is used only to deduplicate records across syncs and restarts.
+
+Bytes 4–5, 10–11 and 14–18 are provisional readings from a small
+number of sessions on one device; corrections welcome.
+
+The deeper multi-session history shown in the phone app is a different
+mechanism: it needs writes to the `ff21` control channel, whose command
+set also contains a factory reset, so it is deliberately not attempted
+here. `ff0c` remains authentication-gated.
 
 ### Advertisement payload
 
@@ -391,9 +526,19 @@ Manufacturer data `0x00DC`, 11 bytes:
 
 ## Troubleshooting
 
-**No live updates during brushing.** Check the `live_connection`
-attribute on the state entity. If it is `false`, the connection was not
-won: disable Bluetooth on the phone or unpair the Oral-B app and retry.
+**No live updates during brushing.** In charger-priority mode (the
+default) this is by design — the brush is silent while the charger
+holds the connection, and the session syncs about a minute after you
+finish. If you want in-session data in Home Assistant, switch the
+entry to live mode via *Configure*, accepting that the iO Sense
+display will stop working. In live mode, check the `live_connection`
+attribute on the state entity: if it is `false`, the connection was
+not won — disable Bluetooth on the phone or unpair the Oral-B app and
+retry.
+
+**Charger display or phone app stopped working.** The entry is in live
+mode and Home Assistant holds the brush's only connection slot. Switch
+to charger-priority mode via *Configure*.
 
 **Entities stop updating entirely.** Reload the integration. If this
 recurs with the official `oralb` integration installed alongside,
@@ -432,4 +577,3 @@ device; other models may differ.
 [hacs-url]: https://github.com/hacs/integration
 [release-badge]: https://img.shields.io/github/v/release/thomasgregg/oralb-ha
 [release-url]: https://github.com/thomasgregg/oralb-ha/releases
-

--- a/custom_components/oralb_live/__init__.py
+++ b/custom_components/oralb_live/__init__.py
@@ -6,7 +6,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ADDRESS, Platform
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
+from .const import CONF_CONNECTION_MODE, DEFAULT_CONNECTION_MODE, DOMAIN
 from .coordinator import OralBLiveCoordinator
 
 PLATFORMS: list[Platform] = [Platform.SENSOR]
@@ -15,11 +15,18 @@ PLATFORMS: list[Platform] = [Platform.SENSOR]
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Oral-B Live from a config entry."""
     address: str = entry.data[CONF_ADDRESS]
-    coordinator = OralBLiveCoordinator(hass, address, entry.title)
+    mode: str = entry.options.get(CONF_CONNECTION_MODE, DEFAULT_CONNECTION_MODE)
+    coordinator = OralBLiveCoordinator(hass, address, entry.title, mode)
     coordinator.async_start()
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    entry.async_on_unload(entry.add_update_listener(_async_options_updated))
     return True
+
+
+async def _async_options_updated(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload the entry when the connection mode changes."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -30,4 +37,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         coordinator: OralBLiveCoordinator = hass.data[DOMAIN].pop(entry.entry_id)
         await coordinator.async_stop()
     return unload_ok
-

--- a/custom_components/oralb_live/config_flow.py
+++ b/custom_components/oralb_live/config_flow.py
@@ -10,10 +10,28 @@ from homeassistant.components.bluetooth import (
     BluetoothServiceInfoBleak,
     async_discovered_service_info,
 )
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigFlow,
+    ConfigFlowResult,
+    OptionsFlow,
+)
 from homeassistant.const import CONF_ADDRESS
+from homeassistant.core import callback
+from homeassistant.helpers.selector import (
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
 
-from .const import DOMAIN, ORALB_MANUFACTURER_ID
+from .const import (
+    CONF_CONNECTION_MODE,
+    CONNECTION_MODE_CHARGER,
+    CONNECTION_MODE_LIVE,
+    DEFAULT_CONNECTION_MODE,
+    DOMAIN,
+    ORALB_MANUFACTURER_ID,
+)
 
 
 def _is_toothbrush(service_info: BluetoothServiceInfoBleak) -> bool:
@@ -31,6 +49,14 @@ class OralBLiveConfigFlow(ConfigFlow, domain=DOMAIN):
     def __init__(self) -> None:
         self._discovery_info: BluetoothServiceInfoBleak | None = None
         self._discovered: dict[str, BluetoothServiceInfoBleak] = {}
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: ConfigEntry,
+    ) -> OralBLiveOptionsFlow:
+        """Return the options flow."""
+        return OralBLiveOptionsFlow()
 
     async def async_step_bluetooth(
         self, discovery_info: BluetoothServiceInfoBleak
@@ -105,3 +131,35 @@ class OralBLiveConfigFlow(ConfigFlow, domain=DOMAIN):
             ),
         )
 
+
+class OralBLiveOptionsFlow(OptionsFlow):
+    """Options: pick who wins the brush's single connection slot."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+        current = self.config_entry.options.get(
+            CONF_CONNECTION_MODE, DEFAULT_CONNECTION_MODE
+        )
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_CONNECTION_MODE, default=current
+                    ): SelectSelector(
+                        SelectSelectorConfig(
+                            options=[
+                                CONNECTION_MODE_CHARGER,
+                                CONNECTION_MODE_LIVE,
+                            ],
+                            translation_key="connection_mode",
+                            mode=SelectSelectorMode.LIST,
+                        )
+                    )
+                }
+            ),
+        )

--- a/custom_components/oralb_live/const.py
+++ b/custom_components/oralb_live/const.py
@@ -12,6 +12,22 @@ DOMAIN = "oralb_live"
 
 ORALB_MANUFACTURER_ID = 220  # 0x00DC, Procter & Gamble
 
+# --- Connection mode ---------------------------------------------------------
+# The brush accepts exactly ONE BLE client at a time and stops
+# advertising while that slot is taken (verified 2026-07 on an iO
+# Series 10 with an iO Sense charger). Whoever holds the slot gets the
+# live data; everyone else gets silence. This is a firmware property of
+# the brush and cannot be engineered away, so it is a per-entry option.
+CONF_CONNECTION_MODE = "connection_mode"
+# Live: Home Assistant seizes and holds the slot; 1 Hz live data in HA,
+# but the iO Sense charger display and the phone app cannot connect.
+CONNECTION_MODE_LIVE = "live"
+# Charger priority: Home Assistant leaves the slot free during
+# sessions (charger lights/timer work as designed) and connects only
+# briefly afterwards to read the brush's own last-session record.
+CONNECTION_MODE_CHARGER = "charger_priority"
+DEFAULT_CONNECTION_MODE = CONNECTION_MODE_CHARGER
+
 # --- GATT characteristics (Oral-B vendor service a0f0ff00-...) ---------------
 CHAR_DEVICE_ID = "a0f0ff01-5047-4d53-8208-4f72616c2d42"  # MAC, reversed
 CHAR_MODEL_ID = "a0f0ff02-5047-4d53-8208-4f72616c2d42"
@@ -24,9 +40,9 @@ CHAR_SECTOR = "a0f0ff09-5047-4d53-8208-4f72616c2d42"  # notify: [sector, ?, tota
 CHAR_PRESSURE = "a0f0ff0b-5047-4d53-8208-4f72616c2d42"  # notify: [state, ...]
 CHAR_SENSOR_DATA = "a0f0ff0d-5047-4d53-8208-4f72616c2d42"  # motion, ~30 Hz
 CHAR_CONTROL = "a0f0ff21-5047-4d53-8208-4f72616c2d42"  # command channel
-CHAR_RTC = "a0f0ff22-5047-4d53-8208-4f72616c2d42"
+CHAR_RTC = "a0f0ff22-5047-4d53-8208-4f72616c2d42"  # seconds, brush epoch
 CHAR_PACER = "a0f0ff26-5047-4d53-8208-4f72616c2d42"  # per-sector seconds
-CHAR_SESSION_DATA = "a0f0ff29-5047-4d53-8208-4f72616c2d42"
+CHAR_SESSION_DATA = "a0f0ff29-5047-4d53-8208-4f72616c2d42"  # last session
 
 NOTIFY_CHARS = (
     CHAR_STATE,
@@ -67,13 +83,26 @@ STATES: dict[int, str] = {
 
 RUNNING_STATE = 3
 
-# States in which the brush is reachable and worth connecting to.
-# Charging (4) is included: the brush accepts a second client while an
-# iO Sense charger is connected, and docked is when we can most reliably
-# establish the link before a session starts.
+# States in which the brush is reachable and worth connecting to in
+# LIVE mode. Charging (4) is included: docked is the most reliable
+# moment to win the free slot before a session starts.
 AWAKE_STATES = {1, 2, 3, 4, 5, 8, 9, 10}
 # States in which the brush will not hold a connection anyway.
 RELEASE_STATES = {114, 115}
+
+# --- Charger-priority mode ---------------------------------------------------
+# Advert states that show a session happened since our last sync.
+SESSION_SEEN_STATES = {3, 8, 9, 10}
+# Advert states quiet enough to sync in without disturbing anyone.
+SYNC_STATES = {2, 4}
+# Never attempt syncs more often than this.
+SYNC_MIN_INTERVAL_SECONDS = 60
+# Refresh battery/state at least this often even without a session.
+PERIODIC_SYNC_INTERVAL_SECONDS = 6 * 3600
+# Sanity bound for a session duration parsed from the ff29 record.
+MAX_SESSION_SECONDS = 7200
+
+STORAGE_VERSION = 1
 
 # iO-series mode identifiers. Unknown values are exposed as "mode_<n>".
 MODES: dict[int, str] = {
@@ -105,12 +134,15 @@ PRESSURE_FROM_ADV: dict[int, str] = {
 
 SIGNAL_UPDATE = f"{DOMAIN}_update"
 
-# Connection management
+# --- Connection management (live mode) ---------------------------------------
 CONNECT_RETRIES = 3
-# Retry interval when we hold no connection. The brush stops advertising
-# while a client is attached, so we cannot rely on advertisements alone
-# to trigger a reconnect.
+# Backstop retry interval while we hold no connection. The brush stops
+# advertising while ANY client holds its single slot, so advertisements
+# alone cannot be relied on to trigger a reconnect.
 RECONNECT_INTERVAL_SECONDS = 30
-# Drop and rebuild a connection that has gone quiet for this long.
+# The brush itself drops clients that stay idle for ~30 s (observed
+# brush-side timeout, 2026-07). Reconnection after such a drop is
+# immediate (see _on_disconnect); this constant only guards against a
+# wedged link whose disconnect callback never fired.
 STALE_CONNECTION_SECONDS = 900
 RELEASE_GRACE_SECONDS = 8

--- a/custom_components/oralb_live/coordinator.py
+++ b/custom_components/oralb_live/coordinator.py
@@ -1,17 +1,25 @@
-"""Hybrid passive/active coordinator for Oral-B Live.
+"""Coordinator for Oral-B Live with two connection modes.
 
-Passive: listens to BLE advertisements (manufacturer id 0x00DC) exactly
-like the official integration, at zero connection cost.
+The brush accepts exactly ONE BLE client at a time and stops
+advertising while that slot is taken. Whoever holds the slot gets the
+data; everyone else -- the iO Sense charger, the phone app, Home
+Assistant -- gets silence. That firmware property forces a choice,
+exposed as the `connection_mode` option:
 
-Active: the moment the brush reports an awake state, we establish a GATT
-connection (through any connectable scanner, e.g. an ESPHome Bluetooth
-proxy with active connections enabled) and subscribe to the live
-notification characteristics -- restoring the 1 Hz brushing timer, live
-pressure, mode and sector that recent iO firmwares no longer broadcast.
+LIVE mode (the v0.4 behaviour): seize and hold the slot whenever it is
+free, subscribe to the live notification characteristics, and stream
+the 1 Hz brushing timer, pressure, quadrant and mode into the
+entities. The trade-off: while we hold the slot, the iO Sense charger
+display and the phone app do not work.
 
-If the connection cannot be won (typically because the Oral-B phone app
-or the iO Sense charger holds it), we degrade gracefully to passive mode
-instead of fighting over the brush.
+CHARGER-PRIORITY mode (default): never compete for the slot. During a
+session the charger connects as designed and its lights/timer work.
+When the brush is idle or docked again after a session -- it frees the
+slot and resumes advertising within ~30 s -- we connect for a few
+seconds, read the brush's own last-session record (ff29), the RTC,
+battery and state, then disconnect. The trade-off: no live in-session
+entities; the session appears about a minute after brushing ends,
+timed by the brush itself.
 """
 
 from __future__ import annotations
@@ -19,6 +27,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from datetime import timedelta
 from typing import Any
 
 from bleak.backends.characteristic import BleakGATTCharacteristic
@@ -37,6 +46,7 @@ from homeassistant.components.bluetooth import (
 from homeassistant.components.bluetooth.match import BluetoothCallbackMatcher
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.storage import Store
 from homeassistant.util import dt as dt_util
 
 from .const import (
@@ -51,23 +61,33 @@ from .const import (
     CHAR_MODE,
     CHAR_PACER,
     CHAR_PRESSURE,
+    CHAR_RTC,
     CHAR_SECTOR,
+    CHAR_SESSION_DATA,
     CHAR_STATE,
     CHAR_STATUS_BLOB,
     CONNECT_RETRIES,
+    CONNECTION_MODE_LIVE,
+    DOMAIN,
+    MAX_SESSION_SECONDS,
     MODES,
     NOTIFY_CHARS,
     ORALB_MANUFACTURER_ID,
+    PERIODIC_SYNC_INTERVAL_SECONDS,
     PRESSURE_FROM_ADV,
     PRESSURE_STATES,
     RECONNECT_INTERVAL_SECONDS,
     RELEASE_GRACE_SECONDS,
     RELEASE_STATES,
     RUNNING_STATE,
-    STALE_CONNECTION_SECONDS,
     SECTOR_NO_SECTOR,
+    SESSION_SEEN_STATES,
     SIGNAL_UPDATE,
+    STALE_CONNECTION_SECONDS,
     STATES,
+    STORAGE_VERSION,
+    SYNC_MIN_INTERVAL_SECONDS,
+    SYNC_STATES,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -81,10 +101,13 @@ def _decode_time(hi: int, lo: int) -> int:
 class OralBLiveCoordinator:
     """Owns all brush state and the BLE connection lifecycle."""
 
-    def __init__(self, hass: HomeAssistant, address: str, name: str) -> None:
+    def __init__(
+        self, hass: HomeAssistant, address: str, name: str, mode: str
+    ) -> None:
         self.hass = hass
         self.address = address
         self.name = name
+        self.mode = mode
         self.data: dict[str, Any] = {
             "state": None,
             "state_raw": None,
@@ -97,6 +120,7 @@ class OralBLiveCoordinator:
             "battery": None,
             "rssi": None,
             "live": False,
+            "connection_mode": mode,
             "last_session_start": None,
             "last_session_duration": None,
             "last_session_mode": None,
@@ -114,13 +138,21 @@ class OralBLiveCoordinator:
         self._unsub_bluetooth: callback | None = None
         self._unsub_unavailable: callback | None = None
         self._stopping = False
-        # --- session tracking ---
+        # --- session tracking (live mode / passive adverts) ---
         self._session_active = False
         self._session_start: Any = None
         self._session_max_time = 0
         self._session_sectors: set[int] = set()
         self._session_high_pressure = 0
         self._last_pressure: str | None = None
+        # --- charger-priority sync state ---
+        self._sync_task: asyncio.Task | None = None
+        self._session_pending_sync = True  # seed on startup
+        self._last_sync_attempt = 0.0
+        self._last_sync_ok = 0.0
+        self._last_synced_session_ts: int | None = None
+        slug = address.replace(":", "").replace("-", "_").lower()
+        self._store: Store = Store(hass, STORAGE_VERSION, f"{DOMAIN}.{slug}")
 
     # ------------------------------------------------------------------ setup
     @callback
@@ -140,16 +172,21 @@ class OralBLiveCoordinator:
             self.hass, self.address, connectable=False
         ):
             self._parse_advertisement(service_info)
-        # The brush stops advertising while a client (for example an
-        # iO Sense charger) is attached, so advertisements alone are not
-        # a reliable trigger. Poll for a connection instead.
-        self._reconnect_task = self.hass.async_create_task(self._reconnect_loop())
+        if self.mode == CONNECTION_MODE_LIVE:
+            # The brush stops advertising while a client (for example an
+            # iO Sense charger) holds its single slot, so advertisements
+            # alone are not a reliable trigger. Poll for a connection.
+            self._reconnect_task = self.hass.async_create_task(
+                self._reconnect_loop()
+            )
 
     async def async_stop(self) -> None:
         self._stopping = True
-        if self._reconnect_task:
-            self._reconnect_task.cancel()
-            self._reconnect_task = None
+        for task in (self._reconnect_task, self._sync_task):
+            if task:
+                task.cancel()
+        self._reconnect_task = None
+        self._sync_task = None
         if self._unsub_bluetooth:
             self._unsub_bluetooth()
             self._unsub_bluetooth = None
@@ -187,8 +224,20 @@ class OralBLiveCoordinator:
             self._apply_sector(payload[ADV_IDX_SECTOR], None)
         self._push()
 
-        if state_raw in AWAKE_STATES and not self._stopping:
-            self._schedule_connect()
+        if self._stopping:
+            return
+        if self.mode == CONNECTION_MODE_LIVE:
+            if state_raw in AWAKE_STATES:
+                self._schedule_connect()
+        else:
+            # Charger priority: never compete for the slot. Note that a
+            # session happened (so a sync is due), and sync only in
+            # quiet states -- which is also the only time the brush
+            # advertises with a free slot anyway.
+            if state_raw in SESSION_SEEN_STATES:
+                self._session_pending_sync = True
+            if state_raw in SYNC_STATES:
+                self._maybe_schedule_sync()
 
     @callback
     def _async_unavailable(self, service_info: BluetoothServiceInfoBleak) -> None:
@@ -222,7 +271,7 @@ class OralBLiveCoordinator:
                     max_attempts=CONNECT_RETRIES,
                 )
             except (BleakError, TimeoutError) as err:
-                # Most likely the phone app or iO Sense holds the brush.
+                # The single slot is taken (charger or phone app).
                 _LOGGER.debug(
                     "%s: could not win connection (%s); staying passive",
                     self.name,
@@ -293,6 +342,146 @@ class OralBLiveCoordinator:
             self._track_session_pressure(self.data["pressure"])
         self._push()
 
+    # ------------------------------------------------- charger-priority sync
+    def _maybe_schedule_sync(self) -> None:
+        """Rate-limited trigger for a post-session / periodic sync."""
+        if self._sync_task and not self._sync_task.done():
+            return
+        now = time.monotonic()
+        if now - self._last_sync_attempt < SYNC_MIN_INTERVAL_SECONDS:
+            return
+        due = (
+            self._session_pending_sync
+            or self._last_sync_ok == 0.0
+            or now - self._last_sync_ok > PERIODIC_SYNC_INTERVAL_SECONDS
+        )
+        if not due:
+            return
+        self._last_sync_attempt = now
+        self._sync_task = self.hass.async_create_task(self._async_sync())
+
+    async def _async_sync(self) -> None:
+        """Connect briefly, read the last-session record, disconnect.
+
+        Total connected time is a few seconds -- far below the brush's
+        own ~30 s idle timeout, and only ever in quiet states, so the
+        charger and app never notice us.
+        """
+        async with self._connect_lock:
+            if self._stopping:
+                return
+            ble_device = bluetooth.async_ble_device_from_address(
+                self.hass, self.address, connectable=True
+            )
+            if ble_device is None:
+                _LOGGER.debug("%s: sync skipped, no connectable path", self.name)
+                return
+            try:
+                client = await establish_connection(
+                    BleakClientWithServiceCache,
+                    ble_device,
+                    self.name,
+                    max_attempts=2,
+                )
+            except (BleakError, TimeoutError) as err:
+                _LOGGER.debug("%s: sync connect failed: %s", self.name, err)
+                return
+            record = rtc = status = state = None
+            try:
+                record = await client.read_gatt_char(CHAR_SESSION_DATA)
+                rtc = await client.read_gatt_char(CHAR_RTC)
+                status = await client.read_gatt_char(CHAR_STATUS_BLOB)
+                state = await client.read_gatt_char(CHAR_STATE)
+            except (BleakError, TimeoutError) as err:
+                _LOGGER.debug("%s: sync read failed: %s", self.name, err)
+            finally:
+                try:
+                    await client.disconnect()
+                except (BleakError, TimeoutError):
+                    pass
+        if status and 0 <= status[0] <= 100:
+            self.data["battery"] = status[0]
+        if state:
+            self._apply_state(state[0])
+        if record is not None:
+            await self._async_apply_session_record(record, rtc)
+        self._last_sync_ok = time.monotonic()
+        self._session_pending_sync = False
+        self._push()
+        _LOGGER.debug("%s: sync complete", self.name)
+
+    async def _async_apply_session_record(
+        self, record: bytes | bytearray, rtc: bytes | bytearray | None
+    ) -> None:
+        """Parse the ff29 last-session record and log new sessions.
+
+        Layout (23 bytes, little-endian, protocol 8):
+          [0:4]   session start, seconds on the brush clock
+          [4:6]   session counter (tentative)
+          [6:8]   target duration, seconds
+          [8:10]  session duration, seconds
+          [10:12] pressure-related count (tentative)
+          [12:14] per-quadrant time, seconds
+          [19]    brushing mode
+          [20]    battery percent at session end
+
+        The brush clock drifts (observed ~8 days off wall time), so the
+        start time is derived RELATIVE to the RTC read in the same
+        connection: wall_start = now - (rtc - record_ts). The raw
+        record timestamp is used only for deduplication, persisted so
+        restarts do not double-count.
+        """
+        if len(record) < 20:
+            _LOGGER.debug(
+                "%s: unexpected ff29 length %s: %s",
+                self.name,
+                len(record),
+                bytes(record).hex(" "),
+            )
+            return
+        session_ts = int.from_bytes(record[0:4], "little")
+        duration = int.from_bytes(record[8:10], "little")
+        mode_raw = record[19]
+        if session_ts == 0 or not 0 < duration <= MAX_SESSION_SECONDS:
+            return
+        if self._last_synced_session_ts is None:
+            stored = await self._store.async_load() or {}
+            self._last_synced_session_ts = stored.get("last_session_ts", 0)
+        if session_ts == self._last_synced_session_ts:
+            return
+
+        rtc_now: int | None = None
+        if rtc is not None and len(rtc) >= 4:
+            rtc_now = int.from_bytes(rtc[0:4], "little")
+        if rtc_now is not None and rtc_now >= session_ts:
+            start = dt_util.utcnow() - timedelta(seconds=rtc_now - session_ts)
+        else:
+            start = dt_util.utcnow()
+
+        today = dt_util.now().date()
+        previous_start = self.data.get("last_session_start")
+        count = self.data.get("sessions_today") or 0
+        if (
+            previous_start is not None
+            and dt_util.as_local(previous_start).date() != today
+        ):
+            count = 0
+        self.data["sessions_today"] = count + 1
+        self.data["last_session_start"] = start
+        self.data["last_session_duration"] = duration
+        self.data["last_session_mode"] = MODES.get(mode_raw, f"mode_{mode_raw}")
+        # Quadrant coverage / high-pressure events are not decoded from
+        # the record yet; passive advert tracking may have filled them.
+        self._last_synced_session_ts = session_ts
+        await self._store.async_save({"last_session_ts": session_ts})
+        _LOGGER.debug(
+            "%s: synced session from brush: %ss, mode %s, started %s",
+            self.name,
+            duration,
+            self.data["last_session_mode"],
+            start,
+        )
+
     # ---------------------------------------------------------- state maps
     def _apply_state(self, raw: int) -> None:
         previous = self.data.get("state_raw")
@@ -315,7 +504,13 @@ class OralBLiveCoordinator:
         _LOGGER.debug("%s: session started", self.name)
 
     def _end_session(self) -> None:
-        """A brushing session just finished; record the result."""
+        """A brushing session just finished; record the result.
+
+        In charger-priority mode this usually records nothing (the
+        brush is silent while the charger holds it, so no duration
+        accumulates); the authoritative record then arrives via the
+        ff29 sync instead.
+        """
         if not self._session_active:
             return
         self._session_active = False
@@ -376,12 +571,13 @@ class OralBLiveCoordinator:
 
     # ------------------------------------------------------------- teardown
     async def _reconnect_loop(self) -> None:
-        """Keep trying to hold a connection.
+        """Live mode: keep trying to hold the connection.
 
-        The brush accepts more than one client, so an attached iO Sense
-        charger does not prevent us from connecting. It does stop the
-        brush advertising, which is why this loop exists rather than
-        relying on advertisement callbacks alone.
+        The brush has a single connection slot and stops advertising
+        while any client holds it, so advertisement callbacks alone
+        cannot trigger reconnects. It also drops idle clients after
+        ~30 s of its own accord; _on_disconnect reconnects immediately
+        when that happens, and this loop is the backstop.
         """
         try:
             while not self._stopping:
@@ -425,8 +621,17 @@ class OralBLiveCoordinator:
     def _on_disconnect(self, _client: BleakClientWithServiceCache) -> None:
         self.data["live"] = False
         self._client = None
-        if not self._stopping:
-            self.hass.loop.call_soon_threadsafe(self._push)
+        if self._stopping:
+            return
+        self.hass.loop.call_soon_threadsafe(self._push)
+        if (
+            self.mode == CONNECTION_MODE_LIVE
+            and self.data.get("state_raw") not in RELEASE_STATES
+        ):
+            # The brush drops idle clients after ~30 s. Reconnect
+            # straight away (instead of waiting for the loop) so a
+            # session never starts while the slot sits free.
+            self.hass.loop.call_soon_threadsafe(self._schedule_connect)
 
     async def _async_disconnect(self) -> None:
         client, self._client = self._client, None
@@ -443,4 +648,3 @@ class OralBLiveCoordinator:
         async_dispatcher_send(
             self.hass, f"{SIGNAL_UPDATE}_{self.address}", self.data
         )
-

--- a/custom_components/oralb_live/manifest.json
+++ b/custom_components/oralb_live/manifest.json
@@ -15,5 +15,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/thomasgregg/oralb-ha/issues",
   "requirements": [],
-  "version": "0.4.0"
+  "version": "0.5.0"
 }

--- a/custom_components/oralb_live/sensor.py
+++ b/custom_components/oralb_live/sensor.py
@@ -197,6 +197,7 @@ class OralBLiveSensor(SensorEntity, RestoreEntity):
         if self.entity_description.key == "toothbrush_state":
             self._attr_extra_state_attributes = {
                 "live_connection": data.get("live"),
+                "connection_mode": data.get("connection_mode"),
                 "rssi": data.get("rssi"),
                 "state_raw": data.get("state_raw"),
                 "mode_raw": data.get("mode_raw"),
@@ -209,4 +210,3 @@ class OralBLiveSensor(SensorEntity, RestoreEntity):
             # Session history stays readable even when the brush is away.
             return True
         return self.coordinator.available
-

--- a/custom_components/oralb_live/strings.json
+++ b/custom_components/oralb_live/strings.json
@@ -15,6 +15,21 @@
       "no_devices_found": "No Oral-B toothbrush found. Wake the brush (press its button) and try again.",
       "already_configured": "Device is already configured"
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "description": "The brush accepts a single Bluetooth connection at a time, so Home Assistant and the iO Sense charger display cannot both be active during a brushing session. Choose who wins.",
+        "data": { "connection_mode": "Connection mode" }
+      }
+    }
+  },
+  "selector": {
+    "connection_mode": {
+      "options": {
+        "charger_priority": "Charger priority — the iO Sense lights and timer work during brushing; the session syncs to Home Assistant right after it ends",
+        "live": "Live — Home Assistant streams the timer, pressure and quadrant at 1 Hz during brushing; the iO Sense display and phone app will not work"
+      }
+    }
   }
 }
-

--- a/custom_components/oralb_live/translations/en.json
+++ b/custom_components/oralb_live/translations/en.json
@@ -15,6 +15,21 @@
       "no_devices_found": "No Oral-B toothbrush found. Wake the brush (press its button) and try again.",
       "already_configured": "Device is already configured"
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "description": "The brush accepts a single Bluetooth connection at a time, so Home Assistant and the iO Sense charger display cannot both be active during a brushing session. Choose who wins.",
+        "data": { "connection_mode": "Connection mode" }
+      }
+    }
+  },
+  "selector": {
+    "connection_mode": {
+      "options": {
+        "charger_priority": "Charger priority — the iO Sense lights and timer work during brushing; the session syncs to Home Assistant right after it ends",
+        "live": "Live — Home Assistant streams the timer, pressure and quadrant at 1 Hz during brushing; the iO Sense display and phone app will not work"
+      }
+    }
   }
 }
-


### PR DESCRIPTION
## What changed

- add charger-priority and live connection modes
- recover completed sessions from the brush session record
- expose connection-mode configuration and translations
- update protocol documentation and bump the integration to 0.5.0

## Why

Oral-B brushes expose one BLE connection slot. Charger-priority mode leaves that slot available during brushing, preserving the iO Sense display and phone-app behavior, then performs a brief post-session sync.

## Impact

Charger priority becomes the default. Users can switch to live mode when in-session 1 Hz updates are preferred over charger and phone-app connectivity.

## Validation

- git diff --check
- Python AST syntax validation
- JSON parsing for manifest, strings, translation, and HACS metadata

GitHub HACS and Hassfest workflows will validate the branch.