### PR TITLE
Record the final session timer from the ending advertisement

### DIFF
--- a/custom_components/oralb_live/coordinator.py
+++ b/custom_components/oralb_live/coordinator.py
@@ -322,9 +322,9 @@ class OralBLiveCoordinator:
             self._push()
             return
         state_raw = payload[ADV_IDX_STATE]
-        self._apply_state(state_raw, track_session=track_session)
         # While live notifications flow, they are fresher than adverts.
-        if not self.data["live"]:
+        adv_live = self.data["live"]
+        if not adv_live:
             self.data["data_source"] = DATA_SOURCE_ADVERTISEMENT
             self.data["time"] = _decode_time(
                 payload[ADV_IDX_TIME_HI], payload[ADV_IDX_TIME_LO]
@@ -332,6 +332,22 @@ class OralBLiveCoordinator:
             self.data["pressure"] = PRESSURE_FROM_ADV.get(
                 payload[ADV_IDX_PRESSURE], "normal"
             )
+            # The advertisement that first reports a quiet state still carries
+            # the timer of the session that just ended, and it is the highest
+            # value the brush ever shows for it. Sampled after _apply_state it
+            # is dropped, because the session is closed by then and
+            # _track_session_time only accepts values while one is active - so
+            # the recorded duration would stay at the last value seen while the
+            # brush was still advertising as running, up to a full advertising
+            # interval short of what the brush displayed.
+            self._track_session_time(self.data["time"], confirm_session=track_session)
+        self._apply_state(state_raw, track_session=track_session)
+        if not adv_live:
+            # The other side of the same transition: a session that begins with
+            # this advertisement was not active when the sample above was
+            # offered, so its first value needs the second chance. Repeating it
+            # is safe - the tracker keeps a maximum, and the timer evidence it
+            # collects only ever counts a value that moved forward.
             self._track_session_time(self.data["time"], confirm_session=track_session)
             self._track_session_pressure(self.data["pressure"])
             self._apply_mode(payload[ADV_IDX_MODE])

--- a/tests/test_coordinator_sessions.py
+++ b/tests/test_coordinator_sessions.py
@@ -1,0 +1,102 @@
+"""Regression tests for passively tracked session durations."""
+
+from __future__ import annotations
+
+import importlib
+import pathlib
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock
+
+COMPONENT_PATH = (
+    pathlib.Path(__file__).parents[1] / "custom_components" / "oralb_live"
+)
+
+# Import the modules without executing the integration's __init__.py, which
+# would pull in the whole Home Assistant setup stack for a decoder test.
+_PACKAGE = types.ModuleType("oralb_live")
+_PACKAGE.__path__ = [str(COMPONENT_PATH)]
+sys.modules.setdefault("oralb_live", _PACKAGE)
+
+try:
+    const = importlib.import_module("oralb_live.const")
+    coordinator = importlib.import_module("oralb_live.coordinator")
+except ImportError as err:  # pragma: no cover - environment without HA
+    raise unittest.SkipTest(f"Home Assistant is not importable: {err}") from err
+
+
+def _advertisement(payload: bytes):
+    """A minimal stand-in for what the bluetooth callback hands over."""
+    return types.SimpleNamespace(
+        manufacturer_data={const.ORALB_MANUFACTURER_ID: payload},
+        rssi=-60,
+        address="AA:BB:CC:DD:EE:FF",
+    )
+
+
+def _payload(state: int, seconds: int, sector: int = 1) -> bytes:
+    """Build a protocol 6 advertisement carrying a state and a timer."""
+    return bytes(
+        [
+            0x06,  # protocol
+            0x31,  # model type
+            0x32,  # firmware
+            state,
+            0x72,  # pressure
+            seconds // 256,
+            seconds % 256,
+            0x00,  # mode
+            sector,
+            0x00,  # total sectors
+            0x00,  # sector timer
+        ]
+    )
+
+
+class PassiveSessionDurationTests(unittest.TestCase):
+    """The recorded duration has to match what the brush displayed."""
+
+    def _coordinator(self):
+        coordinator.async_dispatcher_send = lambda *args, **kwargs: None
+        c = coordinator.OralBLiveCoordinator(
+            MagicMock(), "AA:BB:CC:DD:EE:FF", "test", const.CONNECTION_MODE_CHARGER
+        )
+        c._maybe_schedule_sync = lambda *args, **kwargs: None
+        c._schedule_connect = lambda *args, **kwargs: None
+        return c
+
+    def test_final_timer_of_the_ending_advertisement_is_recorded(self) -> None:
+        """The quiet advertisement carries the session's highest timer value.
+
+        A brush advertises roughly every ten seconds, and the value it sends
+        alongside idle is the one it stopped at. Losing it leaves the record
+        up to a full advertising interval short of the reported time.
+        """
+        c = self._coordinator()
+        for seconds in (5, 60, 123):
+            c._parse_advertisement(_advertisement(_payload(3, seconds)))
+        c._parse_advertisement(_advertisement(_payload(2, 130)))
+
+        self.assertEqual(c.data["time"], 130)
+        self.assertEqual(c.data["last_session_duration"], 130)
+
+    def test_first_running_advertisement_still_starts_the_session(self) -> None:
+        """A session seen for a single advertisement keeps that timer."""
+        c = self._coordinator()
+        c._parse_advertisement(_advertisement(_payload(3, 42)))
+        c._parse_advertisement(_advertisement(_payload(2, 42)))
+
+        self.assertEqual(c.data["last_session_duration"], 42)
+
+    def test_a_quiet_brush_does_not_invent_a_session(self) -> None:
+        """Idle advertisements on their own record nothing."""
+        c = self._coordinator()
+        for _ in range(3):
+            c._parse_advertisement(_advertisement(_payload(2, 0)))
+
+        self.assertIsNone(c.data["last_session_duration"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #8.

The brush sends its highest timer value together with the first quiet state.
Because `_apply_state()` runs before the timer is sampled, `_end_session()` has
already closed the session by the time `_track_session_time()` sees that value,
and it is dropped — leaving the record up to a full advertising interval short
of what the brush displayed.

The sample is now offered before the state transition as well as after it. That
covers both sides of a transition: a session ending with this advertisement
keeps its final value, and one beginning with it still keeps its first. The
repeated call is harmless — the tracker keeps a maximum, and the timer evidence
it collects only counts a value that moved forward.

Nothing else moves. `_track_session_pressure()`, `_apply_mode()` and
`_apply_sector()` stay after `_apply_state()`, so the quiet advertisement's
sector and pressure bytes are treated exactly as before.

### Verification

Replaying seven captured sessions through the coordinator: every duration
matches the brush's own final timer afterwards, none gets shorter, and the
quadrant counts are unchanged.

The new test in `tests/test_coordinator_sessions.py` fails on `main` with
`AssertionError: 123 != 130` and passes with this change. Two further tests
guard the reordering itself: a session seen for a single advertisement still
records its timer, and idle advertisements alone still record nothing.

The test module imports the component without executing `__init__.py`, so it
needs `homeassistant` on the path but no running instance — `python -m unittest
discover -s tests` runs all 36 tests in well under a second.
