### PR TITLE
Fix HACS screenshots and release v0.7.25

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ persistent brushing log, and exposes supported battery, brush-head, display
 and charger diagnostics without using the Oral-B cloud.
 
 <p align="center">
-  <img src="docs/images/toothbrush-device.png" alt="Oral-B Live toothbrush device page in Home Assistant" width="900">
+  <img src="https://raw.githubusercontent.com/thomasgregg/oralb-ha/main/docs/images/toothbrush-device.png" alt="Oral-B Live toothbrush device page in Home Assistant" width="900">
   <br>
   <sub>Toothbrush entities and session activity</sub>
 </p>
 
 <p align="center">
-  <img src="docs/images/io-sense-charger-device.png" alt="Oral-B Live iO Sense charger device page in Home Assistant" width="900">
+  <img src="https://raw.githubusercontent.com/thomasgregg/oralb-ha/main/docs/images/io-sense-charger-device.png" alt="Oral-B Live iO Sense charger device page in Home Assistant" width="900">
   <br>
   <sub>iO Sense charger entities and diagnostics</sub>
 </p>

--- a/custom_components/oralb_live/manifest.json
+++ b/custom_components/oralb_live/manifest.json
@@ -19,5 +19,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/thomasgregg/oralb-ha/issues",
   "requirements": [],
-  "version": "0.7.24"
+  "version": "0.7.25"
 }


### PR DESCRIPTION
## Summary

- use absolute raw GitHub URLs for README screenshots so HACS can load them
- bump the integration version to 0.7.25

## Checks

- image URLs return HTTP 200 with `image/png`
- manifest parses as valid JSON
- `git diff --check`
- HACS and Hassfest validation pending