### PR TITLE
Add HACS ZIP release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release
+
+on:
+  release:
+    types:
+      - published
+
+permissions: {}
+
+jobs:
+  release-zip:
+    name: Publish HACS ZIP asset
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          persist-credentials: false
+
+      - name: Build integration ZIP
+        run: git archive --format=zip --output="$RUNNER_TEMP/oralb_live.zip" HEAD:custom_components/oralb_live
+
+      - name: Upload integration ZIP
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: gh release upload "$RELEASE_TAG" "$RUNNER_TEMP/oralb_live.zip" --clobber

--- a/custom_components/oralb_live/manifest.json
+++ b/custom_components/oralb_live/manifest.json
@@ -19,5 +19,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/thomasgregg/oralb-ha/issues",
   "requirements": [],
-  "version": "0.7.25"
+  "version": "0.7.26"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,6 @@
 {
+  "filename": "oralb_live.zip",
   "name": "Oral-B Live",
-  "render_readme": true
+  "render_readme": true,
+  "zip_release": true
 }
-


### PR DESCRIPTION
## Summary
- configure HACS to install `oralb_live.zip` release assets
- build the integration archive from tracked files at the release tag
- upload the archive automatically whenever a GitHub release is published
- backfill the five releases currently visible in the HACS version picker

## Validation
- verified the archive has `manifest.json` and integration files at its root
- verified the archive excludes ignored local files
- verified `hacs.json` and workflow YAML parse successfully
- full pytest suite not run because pytest is not installed in the workspace runtime