### PR TITLE
Decode the live FF09 sector as zero-based

### DIFF
--- a/custom_components/oralb_live/coordinator.py
+++ b/custom_components/oralb_live/coordinator.py
@@ -503,7 +503,7 @@ class OralBLiveCoordinator:
         elif uuid == CHAR_MODE and payload:
             self._apply_mode(payload[0])
         elif uuid == CHAR_SECTOR and payload:
-            self._apply_sector(
+            self._apply_charger_sector(
                 payload[0],
                 payload[2] if len(payload) >= 3 else None,
                 payload[1] if len(payload) >= 2 else None,

--- a/custom_components/oralb_live/coordinator.py
+++ b/custom_components/oralb_live/coordinator.py
@@ -102,8 +102,8 @@ from .const import (
 from .protocol import (
     advance_pacer_progress,
     advance_session_timer_evidence,
-    decode_charger_sector,
     decode_display_face,
+    decode_ff09_sector,
     decode_sector,
     derive_pacer_progress,
     parse_available_modes,
@@ -503,7 +503,7 @@ class OralBLiveCoordinator:
         elif uuid == CHAR_MODE and payload:
             self._apply_mode(payload[0])
         elif uuid == CHAR_SECTOR and payload:
-            self._apply_charger_sector(
+            self._apply_ff09_sector(
                 payload[0],
                 payload[2] if len(payload) >= 3 else None,
                 payload[1] if len(payload) >= 2 else None,
@@ -567,7 +567,7 @@ class OralBLiveCoordinator:
             self._track_session_time(seconds, confirm_session=True)
             self._update_pacer_progress()
         elif short_uuid == "FF09" and len(raw) >= 3:
-            self._apply_charger_sector(raw[0], raw[2], raw[1])
+            self._apply_ff09_sector(raw[0], raw[2], raw[1])
         elif short_uuid == "FF0A":
             self._apply_smiley(raw)
         elif short_uuid == "FF0B" and raw:
@@ -1337,12 +1337,12 @@ class OralBLiveCoordinator:
             self.data["number_of_sectors"] = decoded_total
         self._apply_pacer_anchor(quadrant, sector_timer)
 
-    def _apply_charger_sector(
+    def _apply_ff09_sector(
         self, raw: int, total: int | None, sector_timer: int | None = None
     ) -> None:
-        """Apply the zero-based quadrant value returned by charger reads."""
+        """Apply a zero-based quadrant value from FF09."""
         self.data["sector_raw"] = raw
-        sector, quadrant, decoded_total = decode_charger_sector(
+        sector, quadrant, decoded_total = decode_ff09_sector(
             raw,
             total,
             self.data.get("number_of_sectors"),

--- a/custom_components/oralb_live/protocol.py
+++ b/custom_components/oralb_live/protocol.py
@@ -261,10 +261,10 @@ def decode_display_face(raw: int) -> int:
     return (raw & 0x38) >> 3
 
 
-def decode_charger_sector(
+def decode_ff09_sector(
     raw: int, total: int | None, configured_total: int | None
 ) -> tuple[str, int | None, int | None]:
-    """Decode the zero-based FF09 pacer sector returned by charger passthrough."""
+    """Decode the zero-based FF09 pacer sector."""
     decoded_total = total if total and 1 <= total <= 8 else configured_total
     if raw == 0xF0:
         return "no_sector", None, decoded_total

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -171,12 +171,11 @@ reads. Unknown future values remain visible as their raw face number.
 `FF08` is elapsed time for the active brushing session. It is unrelated to the
 estimated battery runtime carried by `FF05`.
 
-For the observed direct `FF09` representation, the low three bits carry the
-pacer-sector value. Zero means no sector and `7` represents the configured last
-sector. Charger passthrough uses the zero-based representation documented
-under [Pacer numbering](#pacer-numbering). The sector is the brush's configured
-pacer prompt, not a spatial measurement of where the brush is in the mouth.
-It normally notifies only when the pacer advances at the intervals configured
+For the observed `FF09` representation, direct notifications and charger
+passthrough both carry the zero-based pacer-sector value documented under
+[Pacer numbering](#pacer-numbering). The sector is the brush's configured pacer
+prompt, not a spatial measurement of where the brush is in the mouth. It
+normally notifies only when the pacer advances at the intervals configured
 through `FF26`; a short session can therefore report only one sector.
 
 ### Motion data and mouth-position inference
@@ -504,13 +503,13 @@ entities.
 
 ### Pacer numbering
 
-Direct toothbrush notifications and charger passthrough use different
-presentation rules in the observed payloads. Charger `FF09` pacer IDs are
-zero-based: raw `0` is `sector_1`, raw `3` is `sector_4`, and `0xFF` denotes
-the configured last sector. `0xF0` means that no sector is defined. The
-three-byte value is `[sector, elapsed sector seconds, configured sector count]`.
-Oral-B Live advances this pacer state locally from the `FF26` schedule between
-reads and treats each `FF09` response as an authoritative correction.
+Direct toothbrush notifications and charger passthrough use the same `FF09`
+presentation rules in the observed payloads. Pacer IDs are zero-based: raw `0`
+is `sector_1`, raw `3` is `sector_4`, and `0xFF` denotes the configured last
+sector. `0xF0` means that no sector is defined. The three-byte value is
+`[sector, elapsed sector seconds, configured sector count]`. Oral-B Live
+advances this pacer state locally from the `FF26` schedule between reads and
+treats each `FF09` response as an authoritative correction.
 
 ## Sustained polling benchmark
 
@@ -667,7 +666,7 @@ For that reason Oral-B Live:
 | --- | --- |
 | `charger_protocol.py` | pure advertisement, native packet and passthrough decoders/builders |
 | `charger.py` | automatic pairing, connection lifecycle, serial request scheduler and charger diagnostics |
-| `protocol.py` | pure toothbrush payload decoders including exact `FF29` and zero-based charger zones |
+| `protocol.py` | pure toothbrush payload decoders including exact `FF29` and zero-based `FF09` pacer sectors |
 | `coordinator.py` | source selection, live state, timer/pacer extrapolation, sampled pressure tracking and retained-session reconciliation |
 | `sensor.py` | toothbrush entities plus a separate matched iO Sense device |
 | `tests/test_protocol.py` | captured-packet regression tests with no Home Assistant dependency |

--- a/tests/test_coordinator_sessions.py
+++ b/tests/test_coordinator_sessions.py
@@ -312,10 +312,6 @@ class SessionSyncRetryTests(unittest.TestCase):
         c.hass.async_create_background_task.assert_not_called()
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class LiveSectorNumberingTests(unittest.TestCase):
     """FF09 counts its quadrants from zero, the advertisement from one."""
 
@@ -362,3 +358,7 @@ class LiveSectorNumberingTests(unittest.TestCase):
         c._parse_advertisement(_advertisement(_payload(3, 10, sector=1)))
 
         self.assertEqual(c.data["sector"], "sector_1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_coordinator_sessions.py
+++ b/tests/test_coordinator_sessions.py
@@ -314,3 +314,51 @@ class SessionSyncRetryTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class LiveSectorNumberingTests(unittest.TestCase):
+    """FF09 counts its quadrants from zero, the advertisement from one."""
+
+    def _coordinator(self):
+        coordinator.async_dispatcher_send = lambda *args, **kwargs: None
+        c = coordinator.OralBLiveCoordinator(
+            MagicMock(), "AA:BB:CC:DD:EE:FF", "test", const.CONNECTION_MODE_LIVE
+        )
+        c._maybe_schedule_sync = lambda *args, **kwargs: None
+        c._schedule_connect = lambda *args, **kwargs: None
+        c.data["state_raw"] = const.RUNNING_STATE
+        return c
+
+    def _notify(self, c, quadrant: int, total: int = 4) -> None:
+        """Hand the coordinator one FF09 notification."""
+        char = types.SimpleNamespace(uuid=const.CHAR_SECTOR)
+        c._on_notify(char, bytearray([quadrant, 0, total]))
+
+    def test_the_first_quadrant_is_reported_as_a_sector(self) -> None:
+        """Zero means the first zone, not the absence of one.
+
+        Read as an advertisement value it means "no sector defined", which
+        is why the opening half minute of every session showed no zone at
+        all.
+        """
+        c = self._coordinator()
+        self._notify(c, 0)
+
+        self.assertEqual(c.data["sector"], "sector_1")
+
+    def test_each_quadrant_keeps_its_own_number(self) -> None:
+        """A whole four-zone session, one notification per zone."""
+        c = self._coordinator()
+        for quadrant, expected in enumerate(
+            ("sector_1", "sector_2", "sector_3", "sector_4")
+        ):
+            self._notify(c, quadrant)
+            self.assertEqual(c.data["sector"], expected)
+
+    def test_the_advertisement_still_counts_from_one(self) -> None:
+        """The other wire format is untouched: its 1 is the first zone."""
+        c = self._coordinator()
+        c.data["live"] = False
+        c._parse_advertisement(_advertisement(_payload(3, 10, sector=1)))
+
+        self.assertEqual(c.data["sector"], "sector_1")

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -248,17 +248,17 @@ class ProtocolDecoderTests(unittest.TestCase):
             ("sector_6", 6, 6),
         )
 
-    def test_charger_sector_is_zero_based(self) -> None:
+    def test_ff09_sector_is_zero_based(self) -> None:
         self.assertEqual(
-            protocol.decode_charger_sector(0, 6, None),
+            protocol.decode_ff09_sector(0, 6, None),
             ("sector_1", 1, 6),
         )
         self.assertEqual(
-            protocol.decode_charger_sector(3, None, 6),
+            protocol.decode_ff09_sector(3, None, 6),
             ("sector_4", 4, 6),
         )
         self.assertEqual(
-            protocol.decode_charger_sector(0xF0, None, 6),
+            protocol.decode_ff09_sector(0xF0, None, 6),
             ("no_sector", None, 6),
         )
 


### PR DESCRIPTION
FF09 counts its quadrants from zero, the advertisement byte counts from one. `_apply_charger_sector` already decodes the characteristic's own numbering, but the live notification path ran the same value through `decode_sector`, the advertisement decoder. Every zone was therefore reported one too low.

## What it looks like

Recorder history of a 96-second session on my iO with four 30-second zones, `connection_mode: live`:

| brushing time | `sector` state | `sector_raw` | zone actually being brushed |
|---|---|---|---|
| 0–29 s | `no_sector` | 0 | 1 |
| 30–59 s | `sector_1` | 1 | 2 |
| 60–89 s | `sector_2` | 2 | 3 |
| from 90 s | `sector_3` | 3 | 4 |

The transitions land exactly on 30/60/90 s, so the brush is pacing correctly and only the label is shifted. The first zone is reported as "no sector", because a zero-based first quadrant is `0` and `decode_sector` reads `0` as "no sector defined". The last zone is never reached before the target time. Throughout the session the state sensor reported `data_source: direct_brush`, so these values came from FF09 and not from the beacon.

## The change

One line: the live notification now goes through `_apply_charger_sector`, the same method the charger read already uses. Nothing else moves — `decode_sector` and `decode_charger_sector` are untouched, and the advertisement path keeps the one-based decoder.

That leaves a naming question I did not want to answer for you: `_apply_charger_sector` and `decode_charger_sector` are now both reached from the live path too, so their names describe the transport that happened to arrive first rather than the wire format they decode. Renaming them to something like `_apply_ff09_sector` would read better, but it touches more of your code than the fix needs and `decode_charger_sector` has a test on its current name. Happy to add that to this PR, do it separately, or leave it alone — whichever you prefer.

Three tests: the first quadrant resolves to `sector_1`, a full four-zone run keeps each number, and an advertisement carrying `1` still means the first zone. The first two fail without the change, the third passes either way — it is there to keep the two formats from being merged by accident later. Full suite: 68 passing.

I can test further changes against hardware if useful — I have two iO handles, one in each connection mode.
