### PR TITLE
Improve dashboard refresh feedback and reload stability

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -4,6 +4,7 @@ import {
   Activity,
   BarChart3,
   CalendarDays,
+  Check,
   Download,
   ExternalLink,
   GitBranch,
@@ -91,11 +92,13 @@ function StatCard({ label, value, note, icon, primary = false }: { label: string
 export default function Home() {
   const [releases, setReleases] = useState(FALLBACK_RELEASES);
   const [status, setStatus] = useState<'loading' | 'ready' | 'stale'>('loading');
+  const [refreshState, setRefreshState] = useState<'idle' | 'refreshing' | 'updated' | 'error'>('idle');
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const [range, setRange] = useState<'all' | 'recent'>('all');
 
   const refresh = useCallback(async () => {
-    setStatus((current) => current === 'ready' ? 'ready' : 'loading');
+    setStatus('loading');
+    setRefreshState('refreshing');
     try {
       const response = await fetch(API_URL, {
         cache: 'no-store',
@@ -118,8 +121,10 @@ export default function Home() {
       setReleases(metrics);
       setLastUpdated(new Date());
       setStatus('ready');
+      setRefreshState('updated');
     } catch {
       setStatus('stale');
+      setRefreshState('error');
     }
   }, []);
 
@@ -128,6 +133,12 @@ export default function Home() {
     const timer = window.setInterval(() => void refresh(), 300_000);
     return () => window.clearInterval(timer);
   }, [refresh]);
+
+  useEffect(() => {
+    if (refreshState !== 'updated') return;
+    const timer = window.setTimeout(() => setRefreshState('idle'), 2_400);
+    return () => window.clearTimeout(timer);
+  }, [refreshState]);
 
   const summary = useMemo(() => {
     const total = releases.reduce((sum, release) => sum + release.downloads, 0);
@@ -177,8 +188,25 @@ export default function Home() {
         <div className="hero-refresh">
           <span>Last refreshed</span>
           <strong>{timeAgo(lastUpdated)}</strong>
-          <button type="button" onClick={() => void refresh()} aria-label="Refresh GitHub download data">
-            <RefreshCw size={14} className={status === 'loading' ? 'is-spinning' : ''} /> Refresh data
+          <button
+            type="button"
+            className={`refresh-button state-${refreshState}`}
+            onClick={() => void refresh()}
+            aria-label="Refresh GitHub download data"
+            disabled={refreshState === 'refreshing'}
+          >
+            {refreshState === 'updated'
+              ? <Check size={14} aria-hidden="true" />
+              : <RefreshCw size={14} className={refreshState === 'refreshing' ? 'is-spinning' : ''} aria-hidden="true" />}
+            <span aria-live="polite">
+              {refreshState === 'refreshing'
+                ? 'Refreshing…'
+                : refreshState === 'updated'
+                  ? 'Updated'
+                  : refreshState === 'error'
+                    ? 'Try again'
+                    : 'Refresh data'}
+            </span>
           </button>
         </div>
       </section>

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -37,19 +37,32 @@ type GitHubRelease = {
   }>;
 };
 
-const FALLBACK_RELEASES: ReleaseMetric[] = [
-  { version: 'v0.7.29', downloads: 8, publishedAt: '2026-08-21T19:59:28Z', size: 132757, url: 'https://github.com/thomasgregg/oralb-ha/releases/tag/v0.7.29' },
-  { version: 'v0.7.28', downloads: 9, publishedAt: '2026-08-21T19:13:28Z', size: 132769, url: 'https://github.com/thomasgregg/oralb-ha/releases/tag/v0.7.28' },
-  { version: 'v0.7.27', downloads: 58, publishedAt: '2026-08-21T13:29:19Z', size: 132769, url: 'https://github.com/thomasgregg/oralb-ha/releases/tag/v0.7.27' },
-  { version: 'v0.7.26', downloads: 3, publishedAt: '2026-08-21T13:19:23Z', size: 132769, url: 'https://github.com/thomasgregg/oralb-ha/releases/tag/v0.7.26' },
-  { version: 'v0.7.24', downloads: 0, publishedAt: '2026-08-21T11:46:44Z', size: 132769, url: 'https://github.com/thomasgregg/oralb-ha/releases/tag/v0.7.24' },
-  { version: 'v0.7.23', downloads: 0, publishedAt: '2026-08-21T10:26:11Z', size: 132667, url: 'https://github.com/thomasgregg/oralb-ha/releases/tag/v0.7.23' },
-  { version: 'v0.7.22', downloads: 0, publishedAt: '2026-08-21T09:15:17Z', size: 131808, url: 'https://github.com/thomasgregg/oralb-ha/releases/tag/v0.7.22' },
-  { version: 'v0.7.21', downloads: 0, publishedAt: '2026-08-21T09:04:35Z', size: 131545, url: 'https://github.com/thomasgregg/oralb-ha/releases/tag/v0.7.21' },
-  { version: 'v0.7.20', downloads: 0, publishedAt: '2026-08-20T19:53:04Z', size: 131529, url: 'https://github.com/thomasgregg/oralb-ha/releases/tag/v0.7.20' },
-];
+type DashboardSnapshot = {
+  releases: ReleaseMetric[];
+  updatedAt: string;
+};
 
 const API_URL = 'https://api.github.com/repos/thomasgregg/oralb-ha/releases?per_page=100';
+const CACHE_KEY = 'oralb-live-analytics-snapshot-v1';
+
+function readCachedSnapshot(): DashboardSnapshot | null {
+  try {
+    const cached = window.localStorage.getItem(CACHE_KEY);
+    if (!cached) return null;
+    const snapshot = JSON.parse(cached) as DashboardSnapshot;
+    if (!Array.isArray(snapshot.releases) || !snapshot.releases.length || Number.isNaN(Date.parse(snapshot.updatedAt))) return null;
+    const isValid = snapshot.releases.every((release) => (
+      typeof release.version === 'string'
+      && typeof release.downloads === 'number'
+      && typeof release.publishedAt === 'string'
+      && typeof release.size === 'number'
+      && typeof release.url === 'string'
+    ));
+    return isValid ? snapshot : null;
+  } catch {
+    return null;
+  }
+}
 
 function formatNumber(value: number) {
   return new Intl.NumberFormat('en').format(value);
@@ -69,16 +82,20 @@ function formatDate(value: string) {
 }
 
 function timeAgo(date: Date | null) {
-  if (!date) return 'Using recent snapshot';
+  if (!date) return 'Waiting for GitHub';
   const seconds = Math.max(0, Math.floor((Date.now() - date.getTime()) / 1000));
   if (seconds < 10) return 'Just now';
   if (seconds < 60) return `${seconds}s ago`;
-  return `${Math.floor(seconds / 60)}m ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
 }
 
-function StatCard({ label, value, note, icon, primary = false }: { label: string; value: string; note: ReactNode; icon: ReactNode; primary?: boolean }) {
+function StatCard({ label, value, note, icon, primary = false, loading = false }: { label: string; value: string; note: ReactNode; icon: ReactNode; primary?: boolean; loading?: boolean }) {
   return (
-    <article className={`stat-card${primary ? ' stat-primary' : ''}`}>
+    <article className={`stat-card${primary ? ' stat-primary' : ''}${loading ? ' is-loading' : ''}`} aria-busy={loading}>
       <div className="stat-topline">
         <span className="stat-label">{label}</span>
         <span className="stat-icon" aria-hidden="true">{icon}</span>
@@ -90,10 +107,10 @@ function StatCard({ label, value, note, icon, primary = false }: { label: string
 }
 
 export default function Home() {
-  const [releases, setReleases] = useState(FALLBACK_RELEASES);
+  const [snapshot, setSnapshot] = useState<DashboardSnapshot | null>(() => readCachedSnapshot());
   const [status, setStatus] = useState<'loading' | 'ready' | 'stale'>('loading');
   const [refreshState, setRefreshState] = useState<'idle' | 'refreshing' | 'updated' | 'error'>('idle');
-  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(() => snapshot ? new Date(snapshot.updatedAt) : null);
   const [range, setRange] = useState<'all' | 'recent'>('all');
 
   const refresh = useCallback(async () => {
@@ -118,8 +135,15 @@ export default function Home() {
         }];
       });
       if (metrics.length === 0) throw new Error('No tracked assets found');
-      setReleases(metrics);
-      setLastUpdated(new Date());
+      const updatedAt = new Date().toISOString();
+      const nextSnapshot = { releases: metrics, updatedAt };
+      setSnapshot(nextSnapshot);
+      setLastUpdated(new Date(updatedAt));
+      try {
+        window.localStorage.setItem(CACHE_KEY, JSON.stringify(nextSnapshot));
+      } catch {
+        // The live dashboard still works when storage is unavailable.
+      }
       setStatus('ready');
       setRefreshState('updated');
     } catch {
@@ -140,7 +164,10 @@ export default function Home() {
     return () => window.clearTimeout(timer);
   }, [refreshState]);
 
+  const releases = snapshot?.releases ?? [];
+
   const summary = useMemo(() => {
+    if (!releases.length) return null;
     const total = releases.reduce((sum, release) => sum + release.downloads, 0);
     const leader = [...releases].sort((a, b) => b.downloads - a.downloads)[0];
     const activeCount = Math.max(1, releases.filter((release) => release.downloads > 0).length);
@@ -158,6 +185,8 @@ export default function Home() {
     return [...selected].reverse();
   }, [range, releases]);
   const maxDownloads = Math.max(1, ...chartReleases.map((release) => release.downloads));
+  const isInitialLoad = !summary && status === 'loading';
+  const emptyNote = isInitialLoad ? 'Loading live GitHub data…' : 'GitHub data is temporarily unavailable';
 
   return (
     <main className="dashboard-shell" id="top">
@@ -171,7 +200,7 @@ export default function Home() {
         </a>
         <div className="header-actions">
           <span className={`live-pill status-${status}`}>
-            <i /> {status === 'stale' ? 'Recent snapshot' : status === 'loading' ? 'Connecting…' : 'Live from GitHub'}
+            <i /> {status === 'stale' ? (summary ? 'Recent snapshot' : 'Data unavailable') : status === 'loading' ? 'Connecting…' : 'Live from GitHub'}
           </span>
           <a className="github-button" href="https://github.com/thomasgregg/oralb-ha" target="_blank" rel="noreferrer">
             <GitBranch size={14} aria-hidden="true" /> <span className="github-label">Repository</span> <ExternalLink size={12} aria-hidden="true" />
@@ -212,10 +241,10 @@ export default function Home() {
       </section>
 
       <section className="stats-grid" aria-label="Download summary">
-        <StatCard primary label="Total downloads" value={formatNumber(summary.total)} icon={<Download size={18} />} note={<>Across {releases.length} tracked releases</>} />
-        <StatCard label="Latest release" value={formatNumber(summary.latest.downloads)} icon={<Activity size={18} />} note={<><span className="version-chip">{summary.latest.version}</span> asset downloads</>} />
-        <StatCard label="Most downloaded" value={formatNumber(summary.leader.downloads)} icon={<TrendingUp size={18} />} note={<><span className="version-chip">{summary.leader.version}</span> · {summary.leaderShare}% of total</>} />
-        <StatCard label="Active-release avg." value={formatNumber(summary.average)} icon={<BarChart3 size={18} />} note={<>Average among downloaded versions</>} />
+        <StatCard primary loading={isInitialLoad} label="Total downloads" value={summary ? formatNumber(summary.total) : '—'} icon={<Download size={18} />} note={summary ? <>Across {releases.length} tracked releases</> : emptyNote} />
+        <StatCard loading={isInitialLoad} label="Latest release" value={summary ? formatNumber(summary.latest.downloads) : '—'} icon={<Activity size={18} />} note={summary ? <><span className="version-chip">{summary.latest.version}</span> asset downloads</> : emptyNote} />
+        <StatCard loading={isInitialLoad} label="Most downloaded" value={summary ? formatNumber(summary.leader.downloads) : '—'} icon={<TrendingUp size={18} />} note={summary ? <><span className="version-chip">{summary.leader.version}</span> · {summary.leaderShare}% of total</> : emptyNote} />
+        <StatCard loading={isInitialLoad} label="Active-release avg." value={summary ? formatNumber(summary.average) : '—'} icon={<BarChart3 size={18} />} note={summary ? <>Average among downloaded versions</> : emptyNote} />
       </section>
 
       <section className="analytics-grid">
@@ -234,6 +263,7 @@ export default function Home() {
             <span className="grid-line grid-line-100" />
             <span className="grid-line grid-line-50" />
             <div className="bar-chart" role="img" aria-label="Bar chart showing ZIP downloads by release version">
+              {!summary && <div className={`data-placeholder${isInitialLoad ? ' is-loading' : ''}`}>{emptyNote}</div>}
               {chartReleases.map((release) => (
                 <a className="bar-column" href={release.url} target="_blank" rel="noreferrer" key={release.version} aria-label={`${release.version}: ${release.downloads} downloads`}>
                   <span className="bar-value">{release.downloads || '–'}</span>
@@ -256,23 +286,25 @@ export default function Home() {
             </div>
             <Package size={18} aria-hidden="true" />
           </div>
-          <div className="donut-wrap">
-            <div className="donut" style={{ '--share': `${summary.leaderShare * 3.6}deg` } as CSSProperties}>
-              <div><strong>{summary.leaderShare}%</strong><span>top version</span></div>
+          {summary ? <>
+            <div className="donut-wrap">
+              <div className="donut" style={{ '--share': `${summary.leaderShare * 3.6}deg` } as CSSProperties}>
+                <div><strong>{summary.leaderShare}%</strong><span>top version</span></div>
+              </div>
             </div>
-          </div>
-          <div className="leader-row">
-            <span><i /> {summary.leader.version}</span>
-            <strong>{formatNumber(summary.leader.downloads)}</strong>
-          </div>
-          <div className="leader-row secondary">
-            <span><i /> Other releases</span>
-            <strong>{formatNumber(summary.total - summary.leader.downloads)}</strong>
-          </div>
-          <div className="insight-note">
-            <TrendingUp size={16} />
-            <p><strong>{summary.leader.version}</strong> currently drives most tracked download activity.</p>
-          </div>
+            <div className="leader-row">
+              <span><i /> {summary.leader.version}</span>
+              <strong>{formatNumber(summary.leader.downloads)}</strong>
+            </div>
+            <div className="leader-row secondary">
+              <span><i /> Other releases</span>
+              <strong>{formatNumber(summary.total - summary.leader.downloads)}</strong>
+            </div>
+            <div className="insight-note">
+              <TrendingUp size={16} />
+              <p><strong>{summary.leader.version}</strong> currently drives most tracked download activity.</p>
+            </div>
+          </> : <div className={`insight-placeholder${isInitialLoad ? ' is-loading' : ''}`}>{emptyNote}</div>}
         </aside>
       </section>
 
@@ -290,8 +322,9 @@ export default function Home() {
               <tr><th>Version</th><th>Published</th><th>Asset size</th><th>Share</th><th className="align-right">Downloads</th><th><span className="sr-only">Open</span></th></tr>
             </thead>
             <tbody>
+              {!summary && <tr className="empty-row"><td colSpan={6}>{emptyNote}</td></tr>}
               {releases.map((release, index) => {
-                const share = summary.total ? Math.round((release.downloads / summary.total) * 100) : 0;
+                const share = summary?.total ? Math.round((release.downloads / summary.total) * 100) : 0;
                 return (
                   <tr key={release.version}>
                     <td><span className="release-version">{release.version}</span>{index === 0 && <span className="latest-tag">Latest</span>}</td>

--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -73,6 +73,9 @@ a { color: inherit; text-decoration: none; }
 .hero-refresh > strong { font-size: 16px; letter-spacing: -.02em; }
 .hero-refresh button { align-items: center; background: transparent; border: 0; color: var(--teal-dark); cursor: pointer; display: flex; font-size: 11px; font-weight: 700; gap: 6px; margin: 7px 0 0; padding: 0; }
 .hero-refresh button:hover { color: var(--ink); }
+.hero-refresh button:disabled { cursor: wait; opacity: .7; }
+.hero-refresh button.state-updated { color: var(--teal-dark); }
+.hero-refresh button.state-error { color: #b76530; }
 .is-spinning { animation: spin .8s linear infinite; }
 
 .stats-grid { display: grid; gap: 14px; grid-template-columns: repeat(4, minmax(0, 1fr)); }

--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -90,6 +90,20 @@ a { color: inherit; text-decoration: none; }
 .stat-primary .stat-label, .stat-primary p { color: #acc0d2; }
 .stat-card > strong { display: block; font-size: 43px; letter-spacing: -.06em; line-height: 1; margin: 15px 0 10px; }
 .stat-card p { color: var(--muted); font-size: 11px; margin: 0; }
+.stat-card.is-loading > strong { color: transparent; position: relative; width: 42%; }
+.stat-card.is-loading > strong::after,
+.stat-card.is-loading p::after {
+  animation: shimmer 1.35s ease-in-out infinite;
+  background: linear-gradient(90deg, rgb(107 123 143 / 12%), rgb(107 123 143 / 25%), rgb(107 123 143 / 12%));
+  background-size: 200% 100%;
+  border-radius: 6px;
+  content: '';
+  inset: 0;
+  position: absolute;
+}
+.stat-card.is-loading p { color: transparent; position: relative; width: 72%; }
+.stat-primary.is-loading > strong::after,
+.stat-primary.is-loading p::after { background: linear-gradient(90deg, rgb(255 255 255 / 8%), rgb(255 255 255 / 18%), rgb(255 255 255 / 8%)); background-size: 200% 100%; }
 .version-chip { background: #e6f7f4; border-radius: 5px; color: var(--teal-dark); font-family: var(--font-mono); font-size: 10px; font-weight: 700; padding: 3px 6px; }
 
 .analytics-grid { display: grid; gap: 14px; grid-template-columns: minmax(0, 1.9fr) minmax(280px, .72fr); margin-top: 14px; }
@@ -106,6 +120,9 @@ a { color: inherit; text-decoration: none; }
 .grid-line-100 { top: 20px; }
 .grid-line-50 { top: 52%; }
 .bar-chart { align-items: end; border-bottom: 1px solid var(--line); display: grid; gap: clamp(8px, 1.4vw, 23px); grid-auto-columns: 1fr; grid-auto-flow: column; height: 100%; padding: 0 10px; position: relative; z-index: 1; }
+.data-placeholder, .insight-placeholder { align-items: center; color: var(--muted); display: flex; font-size: 11px; justify-content: center; text-align: center; }
+.data-placeholder { inset: 0; position: absolute; }
+.data-placeholder.is-loading::before, .insight-placeholder.is-loading::before { animation: spin .8s linear infinite; border: 2px solid #dce5ec; border-radius: 50%; border-top-color: var(--teal); content: ''; height: 15px; margin-right: 9px; width: 15px; }
 .bar-column { align-items: center; display: grid; grid-template-rows: 20px 1fr 30px; height: 100%; min-width: 26px; }
 .bar-column:hover .bar-track span { filter: brightness(.9); transform: scaleX(1.06); }
 .bar-value { color: var(--muted); font-size: 10px; font-weight: 750; text-align: center; }
@@ -115,6 +132,7 @@ a { color: inherit; text-decoration: none; }
 .chart-caption { color: #8896a6; font-size: 10px; margin: 14px 0 0; }
 
 .insight-card { padding: 26px 24px; }
+.insight-placeholder { min-height: 266px; }
 .card-heading.compact > svg { color: var(--muted); }
 .donut-wrap { display: flex; justify-content: center; padding: 27px 0 24px; }
 .donut { align-items: center; background: conic-gradient(var(--teal) 0 var(--share), #e8eef2 var(--share) 360deg); border-radius: 50%; display: flex; height: 152px; justify-content: center; position: relative; width: 152px; }
@@ -138,6 +156,7 @@ a { color: inherit; text-decoration: none; }
 table { border-collapse: collapse; min-width: 760px; width: 100%; }
 th { color: #8a98a7; font-size: 9px; font-weight: 750; letter-spacing: .08em; padding: 10px 8px; text-align: left; text-transform: uppercase; }
 td { border-top: 1px solid #edf1f4; color: var(--muted); font-size: 11px; padding: 15px 8px; }
+.empty-row td { height: 92px; text-align: center; }
 .release-version { color: var(--ink); font-family: var(--font-mono); font-size: 11px; font-weight: 750; }
 .latest-tag { background: #e6f7f4; border-radius: 999px; color: var(--teal-dark); font-size: 8px; font-weight: 800; margin-left: 8px; padding: 3px 6px; text-transform: uppercase; }
 .date-cell { align-items: center; display: flex; gap: 6px; white-space: nowrap; }
@@ -159,6 +178,7 @@ footer { color: #8a98a7; display: flex; font-size: 9px; justify-content: space-b
 
 @keyframes spin { to { transform: rotate(360deg); } }
 @keyframes pulse { 50% { opacity: .35; } }
+@keyframes shimmer { to { background-position: -200% 0; } }
 
 @media (max-width: 980px) {
   .analytics-grid { grid-template-columns: 1fr; }


### PR DESCRIPTION
## Summary
- show clear refreshing, updated, and retry states
- remove the hard-coded download snapshot that flashed during browser reloads
- cache the last successful GitHub response for stable reloads
- show neutral loading placeholders when no cached data exists

## Verification
- `npm run build`
- hard-refresh browser test against the production build
- deployed GitHub Pages verification
- HACS and Hassfest checks pass