### PR TITLE
Update GitHub Actions runtimes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write
     steps:
       - name: Check out release tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.release.tag_name }}
           persist-credentials: false

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -25,9 +25,9 @@ jobs:
             python: "3.14"
             requirements: requirements-test-current.txt
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python }}
           cache: pip
@@ -41,7 +41,7 @@ jobs:
     name: HACS
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: HACS validation
         uses: hacs/action@main
         with:
@@ -51,6 +51,6 @@ jobs:
     name: Hassfest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Hassfest validation
         uses: home-assistant/actions/hassfest@master


### PR DESCRIPTION
## Summary
- update actions/checkout from v4 to v7
- update actions/setup-python from v5 to v7
- remove Node.js 20 deprecation warnings from validation and release workflows

## Verification
Protected CI must pass before merge.