### PR TITLE
Gate selection-menu pressure on confirmed sessions

### DIFF
--- a/custom_components/oralb_live/coordinator.py
+++ b/custom_components/oralb_live/coordinator.py
@@ -1171,9 +1171,19 @@ class OralBLiveCoordinator:
     def _is_pressure_active_state(self, raw: int | None = None) -> bool:
         """Return whether pressure is meaningful in the current brush state."""
         state_raw = self.data.get("state_raw") if raw is None else raw
+        if state_raw == RUNNING_STATE:
+            return True
         if self.mode == CONNECTION_MODE_LIVE:
-            return state_raw == RUNNING_STATE
-        return state_raw in PASSIVE_SESSION_ACTIVE_STATES
+            return False
+        # Some passive firmware remains in selection_menu while its motor is
+        # running, but an ordinary mode-button press uses the same state. Only
+        # expose pressure after forward timer progress has confirmed that the
+        # provisional menu observation is a real brushing session.
+        return (
+            state_raw in PASSIVE_SESSION_ACTIVE_STATES
+            and self._session_active
+            and self._session_confirmed
+        )
 
     # ---------------------------------------------------------- sessions
     def _cancel_session_display_face_read(self) -> None:

--- a/custom_components/oralb_live/manifest.json
+++ b/custom_components/oralb_live/manifest.json
@@ -19,5 +19,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/thomasgregg/oralb-ha/issues",
   "requirements": [],
-  "version": "0.7.34b1"
+  "version": "0.7.34b2"
 }

--- a/tests/test_coordinator_sessions.py
+++ b/tests/test_coordinator_sessions.py
@@ -176,12 +176,27 @@ class PassiveSessionDurationTests(unittest.TestCase):
         self.assertIsNone(c.data["pressure_raw"])
         self.assertIsNone(c.data["pressure_source"])
 
-    def test_selection_menu_can_carry_passive_session_pressure(self) -> None:
-        """Firmware using selection_menu for brushing keeps pressure active."""
+    def test_selection_menu_pressure_waits_for_session_confirmation(self) -> None:
+        """An idle mode-button press cannot become retained normal pressure."""
         c = self._coordinator()
         c._parse_advertisement(_advertisement(_payload(8, 0, pressure=0xF2)))
+        c._parse_advertisement(_advertisement(_payload(8, 0, pressure=0x72)))
 
+        self.assertIsNone(c.data["pressure"])
+        self.assertIsNone(c.data["pressure_raw"])
+        self.assertIsNone(c.data["pressure_source"])
+        self.assertTrue(c._session_active)
+        self.assertFalse(c._session_confirmed)
+
+    def test_confirmed_selection_menu_session_carries_pressure(self) -> None:
+        """Timer progress enables pressure for firmware that stays in its menu."""
+        c = self._coordinator()
+        c._parse_advertisement(_advertisement(_payload(8, 0, pressure=0x72)))
+        c._parse_advertisement(_advertisement(_payload(8, 1, pressure=0xF2)))
+
+        self.assertTrue(c._session_confirmed)
         self.assertEqual(c.data["pressure"], "high")
+        self.assertEqual(c.data["pressure_raw"], "f2")
         self.assertEqual(c.data["pressure_source"], const.DATA_SOURCE_ADVERTISEMENT)
 
     def test_direct_mode_requires_running_for_pressure(self) -> None:


### PR DESCRIPTION
Fixes the remaining advertisement-path pressure case reported in #21.

- keep pressure unknown for an unconfirmed `selection_menu` observation
- enable pressure after forward brush-timer progress confirms a passive session
- retain immediate pressure in the genuine running state
- add regressions for menu-only and confirmed menu-state sessions
- bump the prerelease version to `0.7.34b2`

Validation:
- HA 2024.4 / Python 3.12: 134 passed
- HA 2026.8 / Python 3.14: 134 passed