### PR TITLE
Treat pause/resume fragments as one session

### DIFF
--- a/custom_components/oralb_live/const.py
+++ b/custom_components/oralb_live/const.py
@@ -158,6 +158,13 @@ SYNC_RETRY_ATTEMPTS = 4
 # session, so the authoritative record can refine the fallback without
 # incrementing the daily count twice.
 SESSION_RECONCILE_WINDOW_SECONDS = 2 * 60
+# A motor stop can be a temporary pause while the handle keeps the same brush
+# timer. Keep the logical session provisional long enough for the slower
+# advertisement path to expose a resume, then finalize a genuine stop.
+SESSION_PAUSE_GRACE_SECONDS = 20.0
+# A selection-menu route can disambiguate two very short sessions whose sparse
+# timer samples overlap. Larger continuing values remain authoritative.
+SESSION_TIMER_RESET_MAX_SECONDS = 5
 # Refresh battery/state at least this often even without a session.
 PERIODIC_SYNC_INTERVAL_SECONDS = 6 * 3600
 # After the immediate settle/retry sequence, retry an unresolved generation

--- a/custom_components/oralb_live/coordinator.py
+++ b/custom_components/oralb_live/coordinator.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -87,10 +88,12 @@ from .const import (
     SESSION_DISPLAY_FACE_PRE_END_GRACE_SECONDS,
     SESSION_DISPLAY_FACE_READ_RETRY_DELAYS,
     SESSION_DISPLAY_FACE_RESULT_MIN_RAW,
+    SESSION_PAUSE_GRACE_SECONDS,
     SESSION_RECONCILE_WINDOW_SECONDS,
     SESSION_RECORD_SETTLE_SECONDS,
     SESSION_SEEN_STATES,
     SESSION_SYNC_RETRY_BACKOFF_SECONDS,
+    SESSION_TIMER_RESET_MAX_SECONDS,
     SIGNAL_UPDATE,
     SMILEYS,
     STALE_CONNECTION_SECONDS,
@@ -126,6 +129,29 @@ _LOGGER = logging.getLogger(__name__)
 def _decode_time(hi: int, lo: int) -> int:
     """Brush time frames are [minutes, seconds]."""
     return hi * 60 + lo
+
+
+@dataclass
+class _PendingSession:
+    """A physically stopped session awaiting its logical boundary."""
+
+    face_generation: int
+    start: datetime
+    duration: int
+    mode: str | None
+    sectors: set[int]
+    high_pressure: int
+    low_pressure: int
+    high_pressure_time: float
+    low_pressure_time: float
+    pressure_samples: int
+    pressure_force_total: int
+    pressure_force_samples: int
+    pressure_force_max: int | None
+    target_duration: int | None
+    source: str | None
+    duration_source: str
+    display_face: str | None = None
 
 
 class OralBLiveCoordinator:
@@ -234,6 +260,12 @@ class OralBLiveCoordinator:
         self._session_mode: str | None = None
         self._last_pressure: str | None = None
         self._pending_passive_sessions: list[Any] = []
+        self._pending_session: _PendingSession | None = None
+        self._session_finalize_task: asyncio.Task | None = None
+        self._session_pause_grace_seconds = SESSION_PAUSE_GRACE_SECONDS
+        self._resume_timer_baseline: int | None = None
+        self._resume_saw_selection_menu = False
+        self._session_generation_marked = False
         # FF0A and FF04 are independent characteristics, and advertisements
         # carry both fields in one packet only on the passive path. Correlate a
         # transient result with exactly one completed session regardless of
@@ -305,11 +337,15 @@ class OralBLiveCoordinator:
 
     async def async_stop(self) -> None:
         self._stopping = True
+        # Do not lose an already stopped session merely because the integration
+        # is being reloaded during its pause grace period.
+        self._finalize_pending_session()
         for task in (
             self._reconnect_task,
             self._sync_task,
             self._charger_tick_task,
             self._session_face_read_task,
+            self._session_finalize_task,
         ):
             if task:
                 task.cancel()
@@ -317,6 +353,7 @@ class OralBLiveCoordinator:
         self._sync_task = None
         self._charger_tick_task = None
         self._session_face_read_task = None
+        self._session_finalize_task = None
         if self._unsub_bluetooth:
             self._unsub_bluetooth()
             self._unsub_bluetooth = None
@@ -609,7 +646,11 @@ class OralBLiveCoordinator:
         elif short_uuid == "FF2D":
             self._apply_refill(raw)
 
-        if self._charger_session_record and self._charger_session_rtc:
+        if (
+            self._charger_session_record
+            and self._charger_session_rtc
+            and self._pending_session is None
+        ):
             record, rtc = self._charger_session_record, self._charger_session_rtc
             rtc_sampled_at = self._charger_session_rtc_sampled_at
             self._charger_session_record = None
@@ -627,6 +668,51 @@ class OralBLiveCoordinator:
                 self._reset_session_sync_retry()
                 self._last_sync_ok = time.monotonic()
         self._push()
+
+    def _schedule_deferred_charger_session_record(self) -> None:
+        """Apply a charger record only after its physical stop is finalized."""
+        if (
+            self._pending_session is not None
+            or not self._charger_session_record
+            or not self._charger_session_rtc
+            or self._stopping
+        ):
+            return
+        record, rtc = self._charger_session_record, self._charger_session_rtc
+        rtc_sampled_at = self._charger_session_rtc_sampled_at
+        self._charger_session_record = None
+        self._charger_session_rtc = None
+        self._charger_session_rtc_sampled_at = None
+        self.hass.async_create_background_task(
+            self._async_apply_deferred_charger_session_record(
+                record,
+                rtc,
+                rtc_sampled_at,
+            ),
+            "oralb_live_deferred_session_record",
+        )
+
+    async def _async_apply_deferred_charger_session_record(
+        self,
+        record: bytes,
+        rtc: bytes,
+        rtc_sampled_at: datetime | None,
+    ) -> None:
+        """Reconcile one retained charger record after logical finalization."""
+        if (
+            await self._async_apply_session_record(
+                record,
+                rtc,
+                rtc_sampled_at=rtc_sampled_at,
+            )
+            == "new"
+        ):
+            self.data["last_session_source"] = DATA_SOURCE_SESSION
+            self._session_pending_sync = False
+            self._processed_session_generation = self._session_generation
+            self._reset_session_sync_retry()
+            self._last_sync_ok = time.monotonic()
+            self._push()
 
     def _advance_charger_timer(self) -> None:
         """Advance the displayed timer between two-second brush anchors."""
@@ -997,7 +1083,15 @@ class OralBLiveCoordinator:
         if self._last_synced_session_ts is None:
             stored = await self._store.async_load() or {}
             self._last_synced_session_ts = stored.get("last_session_ts", 0)
-        if session_ts == self._last_synced_session_ts:
+        current_duration = self.data.get("last_session_duration")
+        refines_same_timestamp = (
+            session_ts == self._last_synced_session_ts
+            and isinstance(current_duration, int)
+            and duration > current_duration
+            and self.data.get("last_session_source") == DATA_SOURCE_SESSION
+            and self.data.get("last_session_id") == parsed["session_id"]
+        )
+        if session_ts == self._last_synced_session_ts and not refines_same_timestamp:
             _LOGGER.debug(
                 "%s: ff29 still contains the previous session "
                 "(timestamp=%s, duration=%ss)",
@@ -1019,7 +1113,7 @@ class OralBLiveCoordinator:
         today = dt_util.now().date()
         previous_start = self.data.get("last_session_start")
         matched_passive_start = None
-        if self._pending_passive_sessions:
+        if not refines_same_timestamp and self._pending_passive_sessions:
             matched_passive_start = min(
                 self._pending_passive_sessions,
                 key=lambda candidate: abs((start - candidate).total_seconds()),
@@ -1029,10 +1123,12 @@ class OralBLiveCoordinator:
                 > SESSION_RECONCILE_WINDOW_SECONDS
             ):
                 matched_passive_start = None
-        reconciles_passive_session = matched_passive_start is not None
-        if reconciles_passive_session:
+        reconciles_passive_session = (
+            refines_same_timestamp or matched_passive_start is not None
+        )
+        if matched_passive_start is not None:
             self._pending_passive_sessions.remove(matched_passive_start)
-        elif previous_start is not None:
+        elif not refines_same_timestamp and previous_start is not None:
             # After an integration reload only the most recent passive session
             # is restored, not the in-memory queue.
             reconciles_passive_session = (
@@ -1133,7 +1229,10 @@ class OralBLiveCoordinator:
                 raw == RUNNING_STATE if confirm_session is None else confirm_session
             )
             if raw in session_states and previous_tracked not in session_states:
-                self._begin_session(confirmed=confirms_brushing)
+                self._begin_session(
+                    confirmed=confirms_brushing,
+                    selection_menu_route=(raw == 8 or previous_tracked == 8),
+                )
             elif raw in session_states and confirms_brushing:
                 self._confirm_session()
             elif raw not in session_states and previous_tracked in session_states:
@@ -1155,17 +1254,21 @@ class OralBLiveCoordinator:
             track_session
             and self.mode != CONNECTION_MODE_LIVE
             and raw in SESSION_SEEN_STATES
+            and raw not in session_states
             and previous_tracked not in SESSION_SEEN_STATES
         ):
+            # Summary-only observations still need retained-session recovery
+            # when the active running/menu edge was missed entirely.
             self._session_generation += 1
             self._session_pending_sync = True
             self._reset_session_sync_retry()
             _LOGGER.debug(
-                "%s: observed session generation %s in state %s",
+                "%s: observed summary-only session generation %s in state %s",
                 self.name,
                 self._session_generation,
                 self.data["state"],
             )
+
         return session_recorded
 
     def _is_pressure_active_state(self, raw: int | None = None) -> bool:
@@ -1230,13 +1333,20 @@ class OralBLiveCoordinator:
         now = time.monotonic() if observed_at is None else observed_at
         if not self._session_display_face_capture_is_open(generation, now=now):
             return False
-        self.data["last_session_display_face"] = SMILEYS.get(raw, f"face_{raw}")
+        face = SMILEYS.get(raw, f"face_{raw}")
+        if (
+            self._pending_session is not None
+            and self._pending_session.face_generation == generation
+        ):
+            self._pending_session.display_face = face
+        else:
+            self.data["last_session_display_face"] = face
         self._pending_session_face_generation = None
         self._pending_session_face_deadline = 0.0
         _LOGGER.debug(
             "%s: attached display face %s to session generation %s from %s",
             self.name,
-            self.data["last_session_display_face"],
+            face,
             generation,
             source or "unknown source",
         )
@@ -1316,9 +1426,188 @@ class OralBLiveCoordinator:
             if self._session_face_read_task is current_task:
                 self._session_face_read_task = None
 
-    def _begin_session(self, *, confirmed: bool = False) -> None:
-        """A brushing session just started."""
-        self._invalidate_session_display_face_capture(advance_generation=True)
+    def _mark_session_generation(self) -> None:
+        """Record one charger-priority sync generation per logical session."""
+        if self._session_generation_marked:
+            return
+        self._session_generation_marked = True
+        if self.mode == CONNECTION_MODE_LIVE:
+            return
+        self._session_generation += 1
+        self._session_pending_sync = True
+        self._reset_session_sync_retry()
+        _LOGGER.debug(
+            "%s: observed logical session generation %s",
+            self.name,
+            self._session_generation,
+        )
+
+    def _cancel_session_finalize(self) -> None:
+        """Cancel a bounded pending-session timeout."""
+        task, self._session_finalize_task = self._session_finalize_task, None
+        if task and not task.done():
+            try:
+                current_task = asyncio.current_task()
+            except RuntimeError:
+                current_task = None
+            if task is not current_task:
+                task.cancel()
+
+    def _schedule_pending_session_finalize(self) -> bool:
+        """Finalize immediately in tests or after the production pause grace."""
+        pending = self._pending_session
+        if pending is None:
+            return False
+        if self._session_pause_grace_seconds <= 0:
+            return self._finalize_pending_session(pending.face_generation)
+        self._cancel_session_finalize()
+        self._session_finalize_task = self.hass.async_create_background_task(
+            self._async_finalize_pending_session(pending.face_generation),
+            "oralb_live_session_pause_grace",
+        )
+        return False
+
+    async def _async_finalize_pending_session(self, generation: int) -> None:
+        """Finalize a stopped logical session if it did not resume in time."""
+        try:
+            await asyncio.sleep(self._session_pause_grace_seconds)
+            if self._stopping:
+                return
+            if self._finalize_pending_session(generation):
+                self._push()
+        except asyncio.CancelledError:
+            pass
+        finally:
+            if self._session_finalize_task is asyncio.current_task():
+                self._session_finalize_task = None
+
+    def _finalize_pending_session(self, generation: int | None = None) -> bool:
+        """Publish one pending logical session and increment its count once."""
+        pending = self._pending_session
+        if pending is None or (
+            generation is not None and pending.face_generation != generation
+        ):
+            return False
+        self._cancel_session_finalize()
+        self._pending_session = None
+
+        today = dt_util.now().date()
+        previous_start = self.data.get("last_session_start")
+        count = self.data.get("sessions_today") or 0
+        if previous_start is not None:
+            previous_day = dt_util.as_local(previous_start).date()
+            if previous_day != today:
+                count = 0
+        self.data["sessions_today"] = count + 1
+        self.data["last_session_start"] = pending.start
+        self.data["last_session_duration"] = pending.duration
+        self.data["last_session_mode"] = pending.mode
+        self.data["last_session_display_face"] = pending.display_face
+        self.data["last_session_sectors"] = len(pending.sectors)
+        has_pressure_samples = pending.pressure_samples > 0
+        self.data["last_session_high_pressure"] = (
+            pending.high_pressure if has_pressure_samples else None
+        )
+        self.data["last_session_low_pressure"] = (
+            pending.low_pressure if has_pressure_samples else None
+        )
+        self.data["last_session_high_pressure_time"] = (
+            round(pending.high_pressure_time, 1) if has_pressure_samples else None
+        )
+        self.data["last_session_low_pressure_time"] = (
+            round(pending.low_pressure_time, 1) if has_pressure_samples else None
+        )
+        self.data["last_session_average_pressure"] = (
+            round(pending.pressure_force_total / pending.pressure_force_samples)
+            if pending.pressure_force_samples
+            else None
+        )
+        self.data["last_session_maximum_pressure"] = pending.pressure_force_max
+        self.data["last_session_battery_end"] = None
+        self.data["last_session_target_duration"] = pending.target_duration
+        self.data["last_session_id"] = None
+        self.data["last_session_source"] = pending.source
+        self._pending_passive_sessions.append(pending.start)
+        self._pending_passive_sessions = self._pending_passive_sessions[-10:]
+
+        # If a resumed fragment was still ambiguous when the predecessor timed
+        # out, it is now necessarily a distinct logical session.
+        if self._session_active and not self._session_generation_marked:
+            self._mark_session_generation()
+        if (
+            self._session_active
+            and self._session_face_generation != pending.face_generation
+        ):
+            self._invalidate_session_display_face_capture()
+        _LOGGER.debug(
+            "%s: session finalized from %s: %ss, mode %s, %s quadrants, "
+            "%s high-pressure events",
+            self.name,
+            pending.duration_source,
+            pending.duration,
+            pending.mode,
+            len(pending.sectors),
+            pending.high_pressure,
+        )
+        self._schedule_deferred_charger_session_record()
+        return True
+
+    def _merge_pending_session(self, resumed_seconds: int) -> None:
+        """Merge a timer-continuing resumed fragment into its predecessor."""
+        pending = self._pending_session
+        if pending is None:
+            return
+        self._cancel_session_finalize()
+        self._pending_session = None
+        self._invalidate_session_display_face_capture()
+        self._session_start = pending.start
+        self._session_max_time = max(pending.duration, resumed_seconds)
+        self._session_sectors |= pending.sectors
+        self._session_high_pressure += pending.high_pressure
+        self._session_low_pressure += pending.low_pressure
+        self._session_high_pressure_time += pending.high_pressure_time
+        self._session_low_pressure_time += pending.low_pressure_time
+        self._session_pressure_samples += pending.pressure_samples
+        self._session_pressure_force_total += pending.pressure_force_total
+        self._session_pressure_force_samples += pending.pressure_force_samples
+        if pending.pressure_force_max is not None:
+            self._session_pressure_force_max = (
+                pending.pressure_force_max
+                if self._session_pressure_force_max is None
+                else max(
+                    pending.pressure_force_max,
+                    self._session_pressure_force_max,
+                )
+            )
+        self._session_mode = self._session_mode or pending.mode
+        self._session_confirmed = True
+        self._session_generation_marked = True
+        self._resume_timer_baseline = None
+        self._resume_saw_selection_menu = False
+        # Any charger-retained record read at the interim stop is provisional.
+        self._charger_session_record = None
+        self._charger_session_rtc = None
+        self._charger_session_rtc_sampled_at = None
+        _LOGGER.debug(
+            "%s: resumed logical session at %ss after a temporary pause",
+            self.name,
+            resumed_seconds,
+        )
+
+    def _begin_session(
+        self,
+        *,
+        confirmed: bool = False,
+        selection_menu_route: bool = False,
+    ) -> None:
+        """Start a physical fragment, pending timer-based boundary evidence."""
+        resuming_pending = self._pending_session is not None
+        if resuming_pending:
+            # Keep the predecessor's provisional face capture open until the
+            # timer decides whether this is a continuation or a new session.
+            self._session_face_generation += 1
+        else:
+            self._invalidate_session_display_face_capture(advance_generation=True)
         self._session_active = True
         self._session_confirmed = confirmed
         self._session_timer_baseline = None
@@ -1337,7 +1626,18 @@ class OralBLiveCoordinator:
         self._session_pressure_force_max = None
         self._session_mode = self.data.get("mode")
         self._last_pressure = None
-        _LOGGER.debug("%s: session started", self.name)
+        self._resume_timer_baseline = None
+        self._resume_saw_selection_menu = (
+            selection_menu_route if resuming_pending else False
+        )
+        self._session_generation_marked = False
+        if not resuming_pending:
+            self._mark_session_generation()
+        _LOGGER.debug(
+            "%s: %s started",
+            self.name,
+            "resume candidate" if resuming_pending else "session",
+        )
 
     def _confirm_session(self) -> None:
         """Mark a provisional charger/menu observation as real brushing."""
@@ -1346,7 +1646,7 @@ class OralBLiveCoordinator:
             _LOGGER.debug("%s: session confirmed by brush data", self.name)
 
     def _end_session(self) -> bool:
-        """A brushing session just finished; record the result.
+        """Hold a physical stop provisionally until its pause grace expires.
 
         Prefer the brush's advertised/notified timer. If it stays at
         zero, use elapsed wall time between the observed running and
@@ -1355,6 +1655,12 @@ class OralBLiveCoordinator:
         """
         if not self._session_active:
             return False
+        # A resumed fragment that stopped before supplying decisive timer
+        # evidence cannot replace the older pending stop. Finalize the older
+        # logical session, then treat this fragment as its own candidate.
+        if self._pending_session is not None:
+            self._finalize_pending_session()
+            self._invalidate_session_display_face_capture()
         self._accumulate_session_pressure_time(time.monotonic())
         self._session_active = False
         self._cancel_charger_ticker()
@@ -1393,68 +1699,92 @@ class OralBLiveCoordinator:
             )
             return False
 
-        today = dt_util.now().date()
-        previous_start = self.data.get("last_session_start")
-        count = self.data.get("sessions_today") or 0
-        if previous_start is not None:
-            previous_day = dt_util.as_local(previous_start).date()
-            if previous_day != today:
-                count = 0
-        self.data["sessions_today"] = count + 1
-
-        self.data["last_session_start"] = self._session_start
-        self.data["last_session_duration"] = duration
-        self.data["last_session_mode"] = self._session_mode or self.data.get("mode")
-        # The result face arrives after the state transition on the passive
-        # advertisement path. Clear the predecessor now so another source can
-        # never make a new session inherit a face that does not belong to it.
-        self.data["last_session_display_face"] = None
-        self.data["last_session_sectors"] = len(self._session_sectors)
-        has_pressure_samples = self._session_pressure_samples > 0
-        self.data["last_session_high_pressure"] = (
-            self._session_high_pressure if has_pressure_samples else None
+        self._pending_session = _PendingSession(
+            face_generation=self._session_face_generation,
+            start=self._session_start,
+            duration=duration,
+            mode=self._session_mode or self.data.get("mode"),
+            sectors=set(self._session_sectors),
+            high_pressure=self._session_high_pressure,
+            low_pressure=self._session_low_pressure,
+            high_pressure_time=self._session_high_pressure_time,
+            low_pressure_time=self._session_low_pressure_time,
+            pressure_samples=self._session_pressure_samples,
+            pressure_force_total=self._session_pressure_force_total,
+            pressure_force_samples=self._session_pressure_force_samples,
+            pressure_force_max=self._session_pressure_force_max,
+            target_duration=self.data.get("target_duration"),
+            source=self.data.get("data_source"),
+            duration_source=duration_source,
         )
-        self.data["last_session_low_pressure"] = (
-            self._session_low_pressure if has_pressure_samples else None
-        )
-        self.data["last_session_high_pressure_time"] = (
-            round(self._session_high_pressure_time, 1) if has_pressure_samples else None
-        )
-        self.data["last_session_low_pressure_time"] = (
-            round(self._session_low_pressure_time, 1) if has_pressure_samples else None
-        )
-        self.data["last_session_average_pressure"] = (
-            round(
-                self._session_pressure_force_total
-                / self._session_pressure_force_samples
-            )
-            if self._session_pressure_force_samples
-            else None
-        )
-        self.data["last_session_maximum_pressure"] = self._session_pressure_force_max
-        self.data["last_session_battery_end"] = None
-        self.data["last_session_target_duration"] = self.data.get("target_duration")
-        self.data["last_session_id"] = None
-        self.data["last_session_source"] = self.data.get("data_source")
-        self._pending_passive_sessions.append(self._session_start)
-        self._pending_passive_sessions = self._pending_passive_sessions[-10:]
         self._open_session_display_face_capture()
         _LOGGER.debug(
-            "%s: session ended from %s: %ss, mode %s, %s quadrants, "
-            "%s high-pressure events",
+            "%s: physical session stop pending for %ss: %ss from %s",
             self.name,
-            duration_source,
+            self._session_pause_grace_seconds,
             duration,
-            self.data.get("mode"),
-            len(self._session_sectors),
-            self._session_high_pressure,
+            duration_source,
         )
-        return True
+        return self._schedule_pending_session_finalize()
 
     def _track_session_time(
         self, seconds: int, *, confirm_session: bool = False
     ) -> None:
         if not self._session_active:
+            # FF04 and FF08 are independent notifications. A final timer sample
+            # can arrive just after the quiet-state edge that opened the grace.
+            if (
+                confirm_session
+                and self._pending_session is not None
+                and seconds > self._pending_session.duration
+            ):
+                self._pending_session.duration = seconds
+            return
+        if self._pending_session is not None:
+            # Charger-mode display ticks are locally extrapolated and reset to
+            # zero on every physical restart. Only an advertisement or FF08
+            # sample may decide whether the toothbrush timer itself reset.
+            if not confirm_session:
+                return
+            baseline = self._resume_timer_baseline
+            if baseline is None or seconds < baseline:
+                self._resume_timer_baseline = seconds
+                self._session_max_time = seconds
+                return
+            if seconds == baseline:
+                return
+
+            pending_duration = self._pending_session.duration
+            timer_dropped = baseline < pending_duration
+            timer_near_zero = baseline <= SESSION_TIMER_RESET_MAX_SECONDS
+            starts_new_session = (
+                timer_dropped
+                and (timer_near_zero or self._resume_saw_selection_menu)
+            ) or (
+                self._resume_saw_selection_menu and timer_near_zero
+            )
+            if starts_new_session:
+                self._session_max_time = seconds
+                self._session_timer_baseline = baseline
+                self._confirm_session()
+                self._finalize_pending_session()
+                # Once a new timer is proven, no delayed predecessor face can
+                # attach to the session that is now actively brushing.
+                self._invalidate_session_display_face_capture()
+                self._resume_timer_baseline = None
+                self._resume_saw_selection_menu = False
+                return
+
+            if baseline < pending_duration:
+                # A slightly lower packet can be delayed predecessor data, not
+                # a reset. Once samples return above the ending timer, require
+                # another forward step before accepting continuation.
+                if seconds > pending_duration:
+                    self._resume_timer_baseline = seconds
+                self._session_max_time = seconds
+                return
+
+            self._merge_pending_session(seconds)
             return
         if confirm_session and not self._session_confirmed:
             previous_baseline = self._session_timer_baseline
@@ -1693,7 +2023,10 @@ class OralBLiveCoordinator:
         )
         self._last_smiley_sample_source = source or self.data.get("data_source")
         pending_generation = self._pending_session_face_generation
-        if pending_generation is not None:
+        if pending_generation is not None and (
+            not self._session_active
+            or self._session_face_generation == pending_generation
+        ):
             self._capture_session_display_face(
                 raw,
                 generation=pending_generation,

--- a/custom_components/oralb_live/manifest.json
+++ b/custom_components/oralb_live/manifest.json
@@ -19,5 +19,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/thomasgregg/oralb-ha/issues",
   "requirements": [],
-  "version": "0.7.34b2"
+  "version": "0.7.34b3"
 }

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -717,9 +717,17 @@ wall_start = wall_time_at_rtc_read - (brush_rtc - session_timestamp)
 The wall timestamp is stored with the RTC sample, so a retained record and RTC
 that arrive in separate charger requests still form an accurate pair.
 
-The live stream creates the HA session immediately. A later `FF29` record is
-matched to that session and refines it without increasing `sessions_today`
-twice.
+The live stream constructs the local HA session. Once its logical stop is
+finalized, a later `FF29` record is matched to it and refines it without
+increasing `sessions_today` twice.
+
+A quiet motor edge is provisional for 20 seconds because the handle can enter
+`idle` during a temporary pause without resetting `FF08`. A resume is merged
+when authoritative timer samples continue forward; a coherent reset near zero
+starts a new logical session. Sectors, pressure summaries and the original
+start are retained across merged fragments, while an interim display face is
+discarded. Charger-mode extrapolated ticks are display-only and never decide
+this boundary.
 
 `FF29` belongs to the brush and retains its latest summary. It is not a dump
 of a charger queue and does not contain per-second pressure distribution or

--- a/tests/test_coordinator_sessions.py
+++ b/tests/test_coordinator_sessions.py
@@ -72,6 +72,7 @@ class PassiveSessionDurationTests(unittest.TestCase):
         c = coordinator.OralBLiveCoordinator(
             MagicMock(), "AA:BB:CC:DD:EE:FF", "test", mode
         )
+        c._session_pause_grace_seconds = 0
         c._maybe_schedule_sync = lambda *args, **kwargs: None
         c._schedule_connect = lambda *args, **kwargs: None
         return c
@@ -283,6 +284,7 @@ class PassiveSessionDurationTests(unittest.TestCase):
         c = self._coordinator()
         c._parse_advertisement(_advertisement(_payload(3, 30)))
         c._parse_advertisement(_advertisement(_payload(2, 30, face=4)))
+        c._parse_advertisement(_advertisement(_payload(3, 1)))
         c._parse_advertisement(_advertisement(_payload(3, 45)))
         c._parse_advertisement(_advertisement(_payload(2, 45, face=7)))
 
@@ -293,6 +295,7 @@ class PassiveSessionDurationTests(unittest.TestCase):
         c = self._coordinator()
         c._parse_advertisement(_advertisement(_payload(3, 30)))
         c._parse_advertisement(_advertisement(_payload(2, 30, face=4)))
+        c._parse_advertisement(_advertisement(_payload(3, 1)))
         c._parse_advertisement(_advertisement(_payload(3, 45)))
         c._parse_advertisement(_advertisement(_payload(2, 45, face=0)))
 
@@ -304,6 +307,7 @@ class PassiveSessionDurationTests(unittest.TestCase):
         c = coordinator.OralBLiveCoordinator(
             MagicMock(), "AA:BB:CC:DD:EE:FF", "test", const.CONNECTION_MODE_LIVE
         )
+        c._session_pause_grace_seconds = 0
         c.data["last_session_display_face"] = "special_5"
 
         c._apply_state(const.RUNNING_STATE)
@@ -356,6 +360,47 @@ class PassiveSessionDurationTests(unittest.TestCase):
         self.assertEqual(c.data["battery"], 94)
         self.assertIsNotNone(c.data["battery_updated_at"])
         self.assertEqual(c.data["battery_source"], const.DATA_SOURCE_SESSION)
+
+    def test_same_timestamp_longer_record_refines_without_recounting(self) -> None:
+        """A final FF29 may extend an interim record from the same timer run."""
+        c = self._coordinator()
+        record = bytes.fromhex("26e4ff3161017800800064000a001321280201045e")
+        session_ts = int.from_bytes(record[0:4], "little")
+        now = coordinator.dt_util.utcnow()
+        c._last_synced_session_ts = session_ts
+        c.data["last_session_start"] = now
+        c.data["last_session_duration"] = 100
+        c.data["last_session_display_face"] = "special_5"
+        c.data["last_session_id"] = 353
+        c.data["last_session_source"] = const.DATA_SOURCE_SESSION
+        c.data["sessions_today"] = 1
+        c._store.async_save = AsyncMock()
+
+        result = asyncio.run(
+            c._async_apply_session_record(
+                record,
+                record[:4],
+                rtc_sampled_at=now,
+            )
+        )
+
+        self.assertEqual(result, "new")
+        self.assertEqual(c.data["last_session_duration"], 128)
+        self.assertEqual(c.data["last_session_display_face"], "special_5")
+        self.assertEqual(c.data["sessions_today"], 1)
+
+    def test_old_same_timestamp_record_cannot_replace_newer_local_session(self) -> None:
+        c = self._coordinator()
+        record = bytes.fromhex("26e4ff3161017800800064000a001321280201045e")
+        c._last_synced_session_ts = int.from_bytes(record[0:4], "little")
+        c.data["last_session_duration"] = 50
+        c.data["last_session_id"] = None
+        c.data["last_session_source"] = const.DATA_SOURCE_ADVERTISEMENT
+
+        result = asyncio.run(c._async_apply_session_record(record, None))
+
+        self.assertEqual(result, "duplicate")
+        self.assertEqual(c.data["last_session_duration"], 50)
 
     def test_retained_record_preserves_face_when_reconciling_same_session(self) -> None:
         """FF29 refines a passive record but has no replacement face."""
@@ -445,6 +490,317 @@ class PassiveSessionDurationTests(unittest.TestCase):
         self.assertIsNone(c.data["last_session_display_face"])
 
 
+class PauseResumeSessionTests(unittest.TestCase):
+    """One continuing handle timer remains one logical brushing session."""
+
+    def _coordinator(self, mode: str = const.CONNECTION_MODE_CHARGER):
+        coordinator.async_dispatcher_send = lambda *args, **kwargs: None
+        c = coordinator.OralBLiveCoordinator(
+            MagicMock(), "AA:BB:CC:DD:EE:FF", "test", mode
+        )
+        c._session_pause_grace_seconds = 20
+        c._schedule_pending_session_finalize = lambda: False
+        c._maybe_schedule_sync = lambda *args, **kwargs: None
+        c._schedule_connect = lambda *args, **kwargs: None
+        return c
+
+    def test_multiple_continuing_fragments_finalize_once_with_final_face(self) -> None:
+        c = self._coordinator()
+        c._parse_advertisement(_advertisement(_payload(3, 60)))
+        original_start = c._session_start
+        c._parse_advertisement(_advertisement(_payload(2, 69, face=3)))
+
+        self.assertIsNone(c.data["last_session_start"])
+        self.assertEqual(c._pending_session.display_face, "special_3")
+
+        c._parse_advertisement(_advertisement(_payload(3, 69)))
+        c._parse_advertisement(_advertisement(_payload(3, 70)))
+        c._parse_advertisement(_advertisement(_payload(2, 80, face=3)))
+        c._parse_advertisement(_advertisement(_payload(3, 80)))
+        c._parse_advertisement(_advertisement(_payload(3, 81)))
+        c._parse_advertisement(_advertisement(_payload(2, 101, face=4)))
+
+        self.assertTrue(c._finalize_pending_session())
+        self.assertEqual(c.data["sessions_today"], 1)
+        self.assertEqual(c.data["last_session_start"], original_start)
+        self.assertEqual(c.data["last_session_duration"], 101)
+        self.assertEqual(c.data["last_session_display_face"], "special_4")
+        self.assertEqual(c._session_generation, 1)
+        self.assertEqual(len(c._pending_passive_sessions), 1)
+
+    def test_sectors_and_pressure_summaries_merge_without_idle_time(self) -> None:
+        c = self._coordinator(const.CONNECTION_MODE_LIVE)
+        with patch.object(coordinator.time, "monotonic", return_value=100.0):
+            c._apply_state(const.RUNNING_STATE)
+            c._track_session_time(10, confirm_session=True)
+            c._apply_ff09_sector(0, 4)
+        with patch.object(coordinator.time, "monotonic", return_value=101.0):
+            c._apply_pressure(bytes((2, 0, 0, 100, 0)), const.DATA_SOURCE_DIRECT)
+        with patch.object(coordinator.time, "monotonic", return_value=102.0):
+            c._apply_state(2)
+
+        with patch.object(coordinator.time, "monotonic", return_value=110.0):
+            c._apply_state(const.RUNNING_STATE)
+            c._track_session_time(10, confirm_session=True)
+            c._track_session_time(11, confirm_session=True)
+            c._apply_ff09_sector(1, 4)
+        with patch.object(coordinator.time, "monotonic", return_value=111.0):
+            c._apply_pressure(bytes((0, 0, 0, 44, 1)), const.DATA_SOURCE_DIRECT)
+        with patch.object(coordinator.time, "monotonic", return_value=113.0):
+            c._apply_state(2)
+
+        c._finalize_pending_session()
+        self.assertEqual(c.data["last_session_sectors"], 2)
+        self.assertEqual(c.data["last_session_high_pressure"], 1)
+        self.assertEqual(c.data["last_session_low_pressure"], 1)
+        self.assertEqual(c.data["last_session_high_pressure_time"], 1.0)
+        self.assertEqual(c.data["last_session_low_pressure_time"], 2.0)
+        self.assertEqual(c.data["last_session_average_pressure"], 200)
+        self.assertEqual(c.data["last_session_maximum_pressure"], 300)
+
+    def test_selection_menu_and_coherent_reset_create_a_new_session(self) -> None:
+        c = self._coordinator()
+        c._parse_advertisement(_advertisement(_payload(3, 30)))
+        c._parse_advertisement(_advertisement(_payload(2, 30, face=4)))
+
+        c._parse_advertisement(_advertisement(_payload(8, 0)))
+        c._parse_advertisement(_advertisement(_payload(3, 1)))
+
+        self.assertEqual(c.data["sessions_today"], 1)
+        self.assertEqual(c.data["last_session_duration"], 30)
+        self.assertEqual(c.data["last_session_display_face"], "special_4")
+        self.assertEqual(c._session_generation, 2)
+
+        c._parse_advertisement(_advertisement(_payload(2, 5, face=7)))
+        c._finalize_pending_session()
+        self.assertEqual(c.data["sessions_today"], 2)
+        self.assertEqual(c.data["last_session_duration"], 5)
+        self.assertEqual(c.data["last_session_display_face"], "special_7")
+
+    def test_selection_menu_does_not_override_a_large_continuing_timer(self) -> None:
+        c = self._coordinator()
+        c._parse_advertisement(_advertisement(_payload(3, 30)))
+        original_start = c._session_start
+        c._parse_advertisement(_advertisement(_payload(2, 30, face=3)))
+
+        c._parse_advertisement(_advertisement(_payload(8, 30)))
+        c._parse_advertisement(_advertisement(_payload(3, 31)))
+
+        self.assertIsNone(c._pending_session)
+        self.assertEqual(c._session_start, original_start)
+        self.assertIsNone(c.data["sessions_today"])
+
+    def test_selection_menu_disambiguates_overlapping_very_short_timers(self) -> None:
+        c = self._coordinator()
+        c._parse_advertisement(_advertisement(_payload(3, 3)))
+        c._parse_advertisement(_advertisement(_payload(2, 3, face=1)))
+
+        c._parse_advertisement(_advertisement(_payload(8, 3)))
+        c._parse_advertisement(_advertisement(_payload(3, 4)))
+
+        self.assertEqual(c.data["sessions_today"], 1)
+        self.assertEqual(c.data["last_session_duration"], 3)
+        self.assertEqual(c._session_generation, 2)
+
+    def test_equal_short_timer_without_menu_route_can_continue(self) -> None:
+        c = self._coordinator(const.CONNECTION_MODE_LIVE)
+        c._apply_state(const.RUNNING_STATE)
+        c._track_session_time(3, confirm_session=True)
+        original_start = c._session_start
+        c._apply_state(2)
+
+        c._apply_state(const.RUNNING_STATE)
+        c._track_session_time(3, confirm_session=True)
+        c._track_session_time(4, confirm_session=True)
+
+        self.assertIsNone(c._pending_session)
+        self.assertEqual(c._session_start, original_start)
+
+    def test_summary_only_observation_still_requests_retained_session(self) -> None:
+        c = self._coordinator()
+
+        c._apply_state(9)
+
+        self.assertEqual(c._session_generation, 1)
+        self.assertTrue(c._session_pending_sync)
+        self.assertFalse(c._session_active)
+
+    def test_stale_high_timer_before_reset_cannot_merge_sessions(self) -> None:
+        c = self._coordinator(const.CONNECTION_MODE_LIVE)
+        c._apply_state(const.RUNNING_STATE)
+        c._track_session_time(80, confirm_session=True)
+        c._apply_state(2)
+
+        c._apply_state(const.RUNNING_STATE)
+        c._track_session_time(81, confirm_session=True)  # delayed predecessor
+        c._track_session_time(0, confirm_session=True)
+        c._track_session_time(1, confirm_session=True)
+
+        self.assertEqual(c.data["sessions_today"], 1)
+        self.assertEqual(c.data["last_session_duration"], 80)
+        self.assertEqual(c._session_max_time, 1)
+
+    def test_slightly_lower_stale_timer_can_recover_to_continuation(self) -> None:
+        c = self._coordinator(const.CONNECTION_MODE_LIVE)
+        c._apply_state(const.RUNNING_STATE)
+        c._track_session_time(80, confirm_session=True)
+        original_start = c._session_start
+        c._apply_state(2)
+
+        c._apply_state(const.RUNNING_STATE)
+        c._track_session_time(79, confirm_session=True)
+        c._track_session_time(82, confirm_session=True)
+        self.assertIsNotNone(c._pending_session)
+        c._track_session_time(83, confirm_session=True)
+
+        self.assertIsNone(c._pending_session)
+        self.assertEqual(c._session_start, original_start)
+        self.assertEqual(c._session_max_time, 83)
+
+    def test_final_timer_after_idle_updates_the_pending_duration(self) -> None:
+        c = self._coordinator(const.CONNECTION_MODE_LIVE)
+        c._apply_state(const.RUNNING_STATE)
+        c._track_session_time(60, confirm_session=True)
+        c._apply_state(2)
+
+        c._track_session_time(62, confirm_session=True)
+        c._finalize_pending_session()
+
+        self.assertEqual(c.data["last_session_duration"], 62)
+
+    def test_wrong_timeout_generation_cannot_finalize_current_pending_stop(self) -> None:
+        c = self._coordinator(const.CONNECTION_MODE_LIVE)
+        c._apply_state(const.RUNNING_STATE)
+        c._track_session_time(20, confirm_session=True)
+        c._apply_state(2)
+        generation = c._pending_session.face_generation
+
+        self.assertFalse(c._finalize_pending_session(generation + 1))
+        self.assertIsNotNone(c._pending_session)
+        self.assertTrue(c._finalize_pending_session(generation))
+        self.assertEqual(c.data["sessions_today"], 1)
+
+    def test_charger_synthetic_zero_is_not_timer_reset_evidence(self) -> None:
+        c = self._coordinator()
+        c._start_charger_ticker = lambda: None
+        c._cancel_charger_ticker = lambda: None
+        c._advance_charger_timer = lambda: None
+        c._charger_session_started(confirmed=True)
+        original_start = c._session_start
+        c._track_session_time(20, confirm_session=True)
+        c._charger_session_ended()
+
+        c._charger_session_started(confirmed=True)
+        self.assertEqual(c.data["time"], 0)
+        c._charger_timer_anchor = (0, 100.0)
+        with patch.object(coordinator.time, "monotonic", return_value=102.0):
+            coordinator.OralBLiveCoordinator._advance_charger_timer(c)
+        self.assertIsNotNone(c._pending_session)
+        self.assertIsNone(c._resume_timer_baseline)
+        asyncio.run(c._async_apply_charger_passthrough("FF08", b"\x00\x14"))
+        asyncio.run(c._async_apply_charger_passthrough("FF08", b"\x00\x15"))
+
+        self.assertIsNone(c._pending_session)
+        self.assertEqual(c._session_start, original_start)
+        self.assertEqual(c._session_max_time, 21)
+        self.assertEqual(c._session_generation, 1)
+
+    def test_final_ff29_refines_combined_session_without_recounting(self) -> None:
+        c = self._coordinator()
+        c._parse_advertisement(_advertisement(_payload(3, 110)))
+        c._parse_advertisement(_advertisement(_payload(2, 120, face=3)))
+        c._parse_advertisement(_advertisement(_payload(3, 120)))
+        c._parse_advertisement(_advertisement(_payload(3, 121)))
+        c._parse_advertisement(_advertisement(_payload(2, 128, face=6)))
+        c._finalize_pending_session()
+        local_start = c.data["last_session_start"]
+        record = bytes.fromhex("26e4ff3161017800800064000a001321280201045e")
+        c._last_synced_session_ts = 0
+        c._store.async_save = AsyncMock()
+
+        result = asyncio.run(
+            c._async_apply_session_record(
+                record,
+                record[:4],
+                rtc_sampled_at=local_start,
+            )
+        )
+
+        self.assertEqual(result, "new")
+        self.assertEqual(c.data["sessions_today"], 1)
+        self.assertEqual(c.data["last_session_duration"], 128)
+        self.assertEqual(c.data["last_session_display_face"], "special_6")
+        self.assertEqual(c.data["last_session_source"], const.DATA_SOURCE_SESSION)
+
+
+class PauseResumeTimeoutTests(unittest.IsolatedAsyncioTestCase):
+    """A real stop still finalizes after the bounded pause grace."""
+
+    async def test_unresumed_stop_finalizes_after_timeout(self) -> None:
+        coordinator.async_dispatcher_send = lambda *args, **kwargs: None
+        hass = MagicMock()
+        tasks: list[asyncio.Task] = []
+
+        def _create_background_task(coro, name):
+            task = asyncio.create_task(coro, name=name)
+            tasks.append(task)
+            return task
+
+        hass.async_create_background_task.side_effect = _create_background_task
+        c = coordinator.OralBLiveCoordinator(
+            hass,
+            "AA:BB:CC:DD:EE:FF",
+            "test",
+            const.CONNECTION_MODE_LIVE,
+        )
+        c._session_pause_grace_seconds = 0.01
+        c._apply_state(const.RUNNING_STATE)
+        c._track_session_time(12, confirm_session=True)
+        c._apply_state(2)
+
+        self.assertIsNone(c.data["last_session_duration"])
+        await asyncio.gather(*tasks)
+        self.assertEqual(c.data["last_session_duration"], 12)
+        self.assertEqual(c.data["sessions_today"], 1)
+
+    async def test_charger_ff29_waits_for_logical_finalization(self) -> None:
+        coordinator.async_dispatcher_send = lambda *args, **kwargs: None
+        hass = MagicMock()
+        tasks: list[asyncio.Task] = []
+
+        def _create_background_task(coro, name):
+            task = asyncio.create_task(coro, name=name)
+            tasks.append(task)
+            return task
+
+        hass.async_create_background_task.side_effect = _create_background_task
+        c = coordinator.OralBLiveCoordinator(
+            hass,
+            "AA:BB:CC:DD:EE:FF",
+            "test",
+            const.CONNECTION_MODE_CHARGER,
+        )
+        c._session_pause_grace_seconds = 20
+        c._schedule_pending_session_finalize = lambda: False
+        c._store.async_save = AsyncMock()
+        c._last_synced_session_ts = 0
+        c._apply_state(const.RUNNING_STATE)
+        c._track_session_time(128, confirm_session=True)
+        c._apply_state(2)
+        record = bytes.fromhex("26e4ff3161017800800064000a001321280201045e")
+
+        await c._async_apply_charger_passthrough("FF29", record)
+        await c._async_apply_charger_passthrough("FF22", record[:4])
+        self.assertIsNone(c.data["last_session_duration"])
+        self.assertIsNotNone(c._charger_session_record)
+
+        c._finalize_pending_session()
+        await asyncio.gather(*tasks)
+        self.assertEqual(c.data["sessions_today"], 1)
+        self.assertEqual(c.data["last_session_duration"], 128)
+        self.assertEqual(c.data["last_session_source"], const.DATA_SOURCE_SESSION)
+
+
 class ConnectedSessionDisplayFaceRegressionTests(unittest.TestCase):
     """Reproduce display-face loss on connected delivery paths from issue 18."""
 
@@ -453,6 +809,7 @@ class ConnectedSessionDisplayFaceRegressionTests(unittest.TestCase):
         c = coordinator.OralBLiveCoordinator(
             MagicMock(), "AA:BB:CC:DD:EE:FF", "test", mode
         )
+        c._session_pause_grace_seconds = 0
         c._maybe_schedule_sync = lambda *args, **kwargs: None
         c._schedule_connect = lambda *args, **kwargs: None
         c.data["data_source"] = (
@@ -658,6 +1015,7 @@ class ConnectedSessionDisplayFaceReadTests(unittest.IsolatedAsyncioTestCase):
             "test",
             const.CONNECTION_MODE_LIVE,
         )
+        c._session_pause_grace_seconds = 0
         c.data["data_source"] = const.DATA_SOURCE_DIRECT
         return c, tasks
 


### PR DESCRIPTION
## Summary

- treat timer-continuing pause/resume fragments as one logical brushing session
- preserve combined duration, sector, pressure, and final-face data across pauses
- retain genuine timer-reset session boundaries and bounded finalization
- reconcile late FF29 summaries without double-counting
- bump the beta integration version to `0.7.34b3`

## Validation

- Minimum stack: 151 tests passed
- Current stack: 151 tests and 23 subtests passed
- `git diff --check`

Closes #22