### PR TITLE
Decode signed FF0B startup force

### DIFF
--- a/custom_components/oralb_live/coordinator.py
+++ b/custom_components/oralb_live/coordinator.py
@@ -1828,7 +1828,10 @@ class OralBLiveCoordinator:
             self._session_pressure_state_started = observed
         elif self._session_pressure_state_started is None:
             self._session_pressure_state_started = observed
-        if force is not None:
+        # FF0B can report a short negative settling transient when the motor
+        # starts. Keep tracking its pressure state, but do not let a value
+        # that is not applied brushing force distort the session summary.
+        if force is not None and force >= 0:
             self._session_pressure_force_total += force
             self._session_pressure_force_samples += 1
             self._session_pressure_force_max = (

--- a/custom_components/oralb_live/manifest.json
+++ b/custom_components/oralb_live/manifest.json
@@ -19,5 +19,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/thomasgregg/oralb-ha/issues",
   "requirements": [],
-  "version": "0.7.34b3"
+  "version": "0.7.34b4"
 }

--- a/custom_components/oralb_live/protocol.py
+++ b/custom_components/oralb_live/protocol.py
@@ -102,7 +102,8 @@ def parse_pressure_sample(
     The historical keys follow the vendor model's motor-field names. The first
     word behaves as brush-head oscillation angle in hundredths of a degree;
     the second drive-target word's encoding remains unknown. The wire values
-    stay available under their historical raw keys.
+    stay available under their historical raw keys. The force word is signed
+    and can briefly dip below zero while the motor settles at startup.
     """
     if not payload:
         return {}
@@ -110,7 +111,9 @@ def parse_pressure_sample(
     return {
         "pressure_state_raw": payload[0],
         "pressure_force": (
-            int.from_bytes(payload[3:5], "little") if len(payload) >= 5 else None
+            int.from_bytes(payload[3:5], "little", signed=True)
+            if len(payload) >= 5
+            else None
         ),
         "motor_angle_raw": (
             int.from_bytes(payload[5:7], "little") if len(payload) >= 7 else None

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -563,7 +563,7 @@ The observed protocol-8/9 payload is length-gated and little-endian:
 | --- | --- | --- |
 | `0` | pressure state | unsigned byte |
 | `1..2` | timestamp | unsigned 16-bit raw value |
-| `3..4` | force | unsigned 16-bit raw value |
+| `3..4` | force | signed 16-bit raw value |
 | `5..6` | oscillation angle | unsigned 16-bit raw value |
 | `7..8` | drive target | unsigned 16-bit raw value |
 | `9` | identifier | unsigned byte |
@@ -571,6 +571,9 @@ The observed protocol-8/9 payload is length-gated and little-endian:
 The integration exposes the captured force word as a Pressure attribute. It
 also exposes the two drive words as disabled-by-default diagnostic sensors
 named **Oscillation angle** (degrees) and **Drive target (raw)** (unitless).
+Short negative force readings can occur while the motor settles at startup.
+They remain visible in the live raw force attribute but are excluded from the
+session average and maximum, which represent applied brushing force.
 Their historical entity keys remain `motor_angle_raw` and `motor_target_raw` so
 existing entity IDs, dashboards and automations do not break. Unitless angle
 samples recorded by version 0.7.32 remain as their original raw values in

--- a/tests/test_coordinator_sessions.py
+++ b/tests/test_coordinator_sessions.py
@@ -120,6 +120,38 @@ class PassiveSessionDurationTests(unittest.TestCase):
         self.assertIsNone(c.data["motor_angle_raw"])
         self.assertIsNone(c.data["motor_target_raw"])
 
+    def test_negative_startup_force_is_excluded_from_session_summary(self) -> None:
+        samples = (
+            (0, -2000),
+            (1, -510),
+            (2, -23),
+            (0, 163),
+            (1, 2200),
+            (2, 5463),
+        )
+
+        for source in (const.DATA_SOURCE_DIRECT, const.DATA_SOURCE_CHARGER):
+            with self.subTest(source=source):
+                c = self._coordinator(const.CONNECTION_MODE_LIVE)
+                c._apply_state(const.RUNNING_STATE)
+                c._track_session_time(10, confirm_session=True)
+                for pressure_state, force in samples:
+                    payload = bytes((pressure_state, 0, 0)) + force.to_bytes(
+                        2, "little", signed=True
+                    )
+                    c._apply_pressure(payload, source)
+
+                self.assertEqual(c._session_pressure_samples, len(samples))
+                self.assertEqual(c._session_pressure_force_samples, 3)
+                self.assertEqual(c._session_pressure_force_total, 7826)
+                self.assertEqual(c._session_pressure_force_max, 5463)
+                self.assertEqual(c._session_high_pressure, 2)
+                self.assertEqual(c._session_low_pressure, 2)
+
+                c._apply_state(2)
+                self.assertEqual(c.data["last_session_average_pressure"], 2609)
+                self.assertEqual(c.data["last_session_maximum_pressure"], 5463)
+
     def test_idle_pressure_is_unknown_across_source_changes(self) -> None:
         """Reconnects cannot turn an untouched handle into a pressure reading."""
         c = self._coordinator()

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -95,6 +95,13 @@ class ProtocolDecoderTests(unittest.TestCase):
         )
         self.assertEqual(protocol.parse_pressure_sample(b""), {})
 
+    def test_pressure_sample_force_is_signed(self) -> None:
+        settling = protocol.parse_pressure_sample(bytes.fromhex("01 00 00 30 f8"))
+        valid = protocol.parse_pressure_sample(bytes.fromhex("01 00 00 57 15"))
+
+        self.assertEqual(settling["pressure_force"], -2000)
+        self.assertEqual(valid["pressure_force"], 5463)
+
     def test_advertisement_pressure_uses_high_bit(self) -> None:
         """Advertisement byte 4 is a bit field, not a lookup or nibble."""
         for status in (0x30, 0x32, 0x38, 0x3A, 0x52, 0x72):


### PR DESCRIPTION
Addresses #26; hardware validation remains requested before closing it.

- decode the FF0B force word as signed little-endian int16
- exclude negative motor-start settling samples from local pressure averages and maxima
- preserve all pressure-state tracking and non-negative force measurements
- cover direct and charger-forwarded session aggregation
- document the signed field and aggregate behavior

Validation:
- 153 tests passed on the current HA 2026.8 / Python 3.14 environment
- 153 tests passed on the minimum HA 2024.4 / Python 3.12 environment
- `git diff --check` passed