### PR TITLE
Expose display face transport provenance

### DIFF
--- a/custom_components/oralb_live/coordinator.py
+++ b/custom_components/oralb_live/coordinator.py
@@ -152,6 +152,7 @@ class _PendingSession:
     source: str | None
     duration_source: str
     display_face: str | None = None
+    display_face_source: str | None = None
 
 
 class OralBLiveCoordinator:
@@ -181,6 +182,7 @@ class OralBLiveCoordinator:
             "target_duration": None,
             "smiley": None,
             "smiley_raw": None,
+            "smiley_source": None,
             "battery": None,
             "battery_time_remaining": None,
             "battery_voltage": None,
@@ -215,6 +217,7 @@ class OralBLiveCoordinator:
             "last_session_duration": None,
             "last_session_mode": None,
             "last_session_display_face": None,
+            "last_session_display_face_source": None,
             "last_session_sectors": None,
             "last_session_high_pressure": None,
             "last_session_low_pressure": None,
@@ -1164,6 +1167,7 @@ class OralBLiveCoordinator:
                     advance_generation=True
                 )
                 self.data["last_session_display_face"] = None
+                self.data["last_session_display_face_source"] = None
             self.data["last_session_start"] = start
             self.data["last_session_duration"] = duration
             self.data["last_session_mode"] = MODES.get(mode_raw, f"mode_{mode_raw}")
@@ -1344,8 +1348,10 @@ class OralBLiveCoordinator:
             and self._pending_session.face_generation == generation
         ):
             self._pending_session.display_face = face
+            self._pending_session.display_face_source = source
         else:
             self.data["last_session_display_face"] = face
+            self.data["last_session_display_face_source"] = source
         self._pending_session_face_generation = None
         self._pending_session_face_deadline = 0.0
         _LOGGER.debug(
@@ -1508,6 +1514,7 @@ class OralBLiveCoordinator:
         self.data["last_session_duration"] = pending.duration
         self.data["last_session_mode"] = pending.mode
         self.data["last_session_display_face"] = pending.display_face
+        self.data["last_session_display_face_source"] = pending.display_face_source
         self.data["last_session_sectors"] = len(pending.sectors)
         has_pressure_samples = pending.pressure_samples > 0
         self.data["last_session_high_pressure"] = (
@@ -2040,12 +2047,13 @@ class OralBLiveCoordinator:
         observed_at = time.monotonic()
         self.data["smiley_raw"] = raw
         self.data["smiley"] = SMILEYS.get(raw, f"face_{raw}")
+        self.data["smiley_source"] = source or self.data.get("data_source")
         self._last_smiley_sample_raw = raw
         self._last_smiley_sample_monotonic = observed_at
         self._last_smiley_sample_generation = (
             self._session_face_generation if self._session_active else None
         )
-        self._last_smiley_sample_source = source or self.data.get("data_source")
+        self._last_smiley_sample_source = self.data["smiley_source"]
         pending_generation = self._pending_session_face_generation
         if pending_generation is not None and (
             not self._session_active

--- a/custom_components/oralb_live/sensor.py
+++ b/custom_components/oralb_live/sensor.py
@@ -539,6 +539,9 @@ class OralBLiveSensor(SensorEntity, RestoreEntity):
                     "last_session_duration": last.attributes.get("duration_seconds"),
                     "last_session_mode": last.attributes.get("mode"),
                     "last_session_display_face": last.attributes.get("display_face"),
+                    "last_session_display_face_source": last.attributes.get(
+                        "display_face_source"
+                    ),
                     "last_session_sectors": last.attributes.get("quadrants_covered"),
                     "last_session_high_pressure": last.attributes.get(
                         "high_pressure_events"
@@ -601,6 +604,7 @@ class OralBLiveSensor(SensorEntity, RestoreEntity):
                 "duration_seconds": data.get("last_session_duration"),
                 "mode": data.get("last_session_mode"),
                 "display_face": data.get("last_session_display_face"),
+                "display_face_source": data.get("last_session_display_face_source"),
                 "quadrants_covered": data.get("last_session_sectors"),
                 "high_pressure_events": data.get("last_session_high_pressure"),
                 "low_pressure_events": data.get("last_session_low_pressure"),
@@ -691,6 +695,7 @@ class OralBLiveSensor(SensorEntity, RestoreEntity):
         elif self.entity_description.key == "smiley":
             self._attr_extra_state_attributes = {
                 "smiley_raw": data.get("smiley_raw"),
+                "source": data.get("smiley_source"),
             }
         elif self.entity_description.key == "ring_color":
             self._attr_extra_state_attributes = {

--- a/docs/smiley-hardware-validation.md
+++ b/docs/smiley-hardware-validation.md
@@ -1,0 +1,130 @@
+# Display-face hardware validation
+
+This working log correlates the physical Oral-B handle display with the raw
+display-face value exposed by Oral-B Live. It supports
+[Toothbrush Card issue #20](https://github.com/mtheli/toothbrush-card/issues/20).
+
+## Test device
+
+| Field | Value |
+| --- | --- |
+| Retail model | Oral-B iO 10 |
+| Home Assistant device | iO Series Toothbrush 64D3 |
+| Oral-B model reported over BLE | iO Series (`model_id` 54) |
+| BLE protocol | 8 |
+| Firmware | `00.82.26` (`firmware_revision` 82) |
+| Secondary controller | 0 |
+| Media content | 26 |
+| Oral-B Live connection mode | Charger priority |
+| iO Sense bridge | Used when available |
+
+The retail model was supplied by the tester; it is not distinguishable from
+the generic BLE model information reported by the brush.
+
+## Method
+
+1. Start the physical brush and run it for the planned duration.
+2. Stop it normally.
+3. Immediately observe or photograph the result shown on the handle.
+4. Read the retained `display_face` from the Oral-B Live **Last session**
+   entity through Home Assistant MCP.
+5. Record the session duration, mode, physical display and reported value.
+
+Durations are observations, not assumed thresholds. Repeat controlled runs to
+separate stable display mappings from session-scoring variation.
+
+## Observations
+
+| Run | Controlled | Duration | Mode | Oral-B Live value | Physical display | Source | Notes |
+| ---: | :---: | ---: | --- | --- | --- | --- | --- |
+| 0 | No | 29 s | Tongue clean | `special_9` | Not observed | iO Sense charger bridge | Pre-test baseline retained by Home Assistant; do not use as a decoded mapping without a matching display observation. |
+| 1 | Yes | 22 s | Tongue clean | `special_6` | Blue smiling face with two round eyes and an upturned curved mouth | iO Sense charger bridge | The handle display also showed `0:22`. The live Smiley entity had already returned to `off`; the value was recovered from the retained Last session `display_face`. |
+| 2 | Yes | 21 s live / 22 s retained | Daily clean | No result (`display_face: null`) | Pause/paused display; no face | iO Sense charger bridge, then retained session | Smiley stayed `off` with raw value 0. |
+| 3 | Yes | 21 s live / 22 s retained | Daily clean | No result (`display_face: null`) | Pause/paused display; no face | iO Sense charger bridge, then retained session | Repeated result. Smiley stayed `off` with raw value 0. |
+| 4 | No | 12 s live / 13 s retained | Intense at start; switched to Daily clean at 9 s | No result (`display_face: null`) | Not observed | iO Sense charger bridge, then retained session | Unplanned setup run. Smiley stayed `off` with raw value 0; provenance changed from `advertisement` to `charger_bridge` during the run and back to `advertisement` afterward. Do not use as a decoded mapping. |
+| 5 | Yes | 118 s live / 119 s retained | Daily clean | `special_5` (raw 5) | Blue smiling face with two round eyes and an upturned curved mouth | iO Sense charger bridge, then retained session | Photo `IMG_3323.HEIC` shows `1:59` and four completed quadrant dots. The result arrived about 2 s after switch-off and was preserved with `display_face_source: charger_bridge`. |
+| 6 | Yes | 111 s | Daily clean | Advertisement: `off` (raw 0); later direct FF0A: `special_5` (raw 5) | Blue smiling face with two round eyes and an upturned curved mouth | Toothbrush advertisement, then direct brush | Photo `IMG_3325.heic` shows `1:51` and four completed quadrant dots. The advertisement stream captured every timer second but emitted no result face; a direct connection to the unchanged saved session then read FF0A as 5. |
+
+### Run 5 capture
+
+All timestamps below are Home Assistant local time (Europe/Berlin) on
+2026-08-26.
+
+| Event or measurement | Captured value |
+| --- | --- |
+| Selection menu observed | 12:38:24.510 |
+| Running observed | 12:38:28.095 |
+| Brush stopped / idle | 12:40:27.344 |
+| Live timer at stop | 118 s |
+| Result signal | 12:40:29.339: `special_5`, raw 5, source `charger_bridge` |
+| Retained session received | 12:40:47.347 |
+| Retained duration / target | 119 s / 120 s |
+| Retained mode / quadrants | Daily clean / 4 |
+| Retained display result | `special_5`, source `charger_bridge` |
+| Photographed handle display | Blue smiling face with two round eyes and an upturned curved mouth; `1:59`; four completed quadrant dots |
+| Retained pressure summary | 0 high-pressure events; 1 low-pressure event; 119 s low; average 600 mN; maximum 600 mN |
+| Battery | 99% at end; estimated runtime changed to 8,982 s |
+| Sessions today | 8 before retained processing, 9 afterward |
+| Smiley reset | 12:40:57.347: `off`, raw 0, source `advertisement` |
+| Charger session ended | 12:40:58.323: `inactive` |
+
+### Run 6 capture
+
+The iO Sense charger was powered off and Oral-B Live confirmed
+`data_source: advertisement` before the session. The handle was stopped
+manually at exactly 1:51.
+
+| Event or measurement | Captured value |
+| --- | --- |
+| Running observed | 12:48:06.058 |
+| Brush entered post-brushing summary | 12:49:57.311 |
+| Final timer | 111 s (`1:51`) |
+| Mode / sectors | Daily clean / sectors 1 through 4 |
+| Live pressure | `normal`, source `advertisement` |
+| Smiley throughout capture | `off`, raw 0, source `advertisement` |
+| Photographed handle display | Blue smiling face with two round eyes and an upturned curved mouth; `1:51`; four completed quadrant dots |
+| Immediate session record | 111 s, target 120 s, 4 quadrants, source `advertisement` |
+| Immediate retained face | `display_face: null`, `display_face_source: null` |
+| Charger state | `not_connected`; session `inactive` throughout |
+| Direct connection established | 12:57:30.894: `data_source: direct_brush`, `live_connection: true` |
+| Direct FF0A result | `special_5`, raw 5, source `direct_brush` |
+| Direct battery read | 98%, source `direct_brush` |
+
+## Issue-ready conclusion
+
+One controlled observation on BLE model ID 54, protocol 8, firmware
+`00.82.26` pairs `special_6` with an ordinary blue smiling face with round eyes
+and an upturned mouth after a 22-second tongue-clean session. It is not the
+star-eyed face reported for `special_6` on the issue author's iO6 and iO8.
+
+Two matching 21/22-second Daily Clean runs showed only the handle's paused
+display and produced no FF0A result: Smiley stayed raw 0 (`off`) and the
+retained session kept `display_face: null`. Oral-B Live did not incorrectly
+inherit the earlier tongue-clean face.
+
+This demonstrates that the short-session behaviour reported for the iO6/iO8
+does not reproduce on this iO 10: at roughly 22 seconds in Daily Clean it emits
+no `standard`/frown result at all, while Tongue Clean can emit `special_6` with
+an ordinary smile. The observations suggest that mode and/or iO 10 firmware
+affect whether a result face is produced and how its value is numbered. Over
+BLE the iO 10 reports only the generic `iO Series` name and model ID 54.
+
+A photographed 119-second Daily Clean session now pairs `special_5` (raw 5)
+with the same visible ordinary blue smile previously paired with `special_6`
+after a 22-second Tongue Clean session on this brush. The photo also matches
+the retained duration (`1:59`) and four-quadrant report. Therefore the raw
+`special_N` number cannot safely be treated as a globally unique face design,
+even on one handle and firmware version; the integration and card should
+preserve the raw value and its provenance rather than assigning a universal
+semantic label without more protocol evidence.
+
+Run 6 adds a stronger transport-specific result: with the iO Sense powered
+off, the advertisement stream captured the complete 111-second Daily Clean
+session but exposed raw face 0 (`off`) throughout, even though a photograph
+shows the handle displaying the ordinary blue smile at 1:51. On this iO 10,
+the advertised three-bit field therefore did not represent the visible
+post-session face in this controlled run. Home Assistant was then switched to
+a direct brush connection without starting another session. Its initial FF0A
+read returned raw 5 (`special_5`) for that same still-current result, matching
+the photographed ordinary smile. This is a controlled same-session transport
+disagreement: advertisement raw 0 versus direct FF0A raw 5.

--- a/tests/test_coordinator_sessions.py
+++ b/tests/test_coordinator_sessions.py
@@ -259,7 +259,12 @@ class PassiveSessionDurationTests(unittest.TestCase):
         c._parse_advertisement(_advertisement(_payload(2, 69, face=5)))
 
         self.assertEqual(c.data["smiley"], "special_5")
+        self.assertEqual(c.data["smiley_source"], const.DATA_SOURCE_ADVERTISEMENT)
         self.assertEqual(c.data["last_session_display_face"], "special_5")
+        self.assertEqual(
+            c.data["last_session_display_face_source"],
+            const.DATA_SOURCE_ADVERTISEMENT,
+        )
 
     def test_ending_advertisement_without_result_keeps_face_unknown(self) -> None:
         """Display-off is not a substitute for a missing session verdict."""
@@ -298,7 +303,12 @@ class PassiveSessionDurationTests(unittest.TestCase):
         c._parse_advertisement(_advertisement(_payload(2, 0, face=0)))
 
         self.assertEqual(c.data["smiley"], "off")
+        self.assertEqual(c.data["smiley_source"], const.DATA_SOURCE_ADVERTISEMENT)
         self.assertEqual(c.data["last_session_display_face"], "special_5")
+        self.assertEqual(
+            c.data["last_session_display_face_source"],
+            const.DATA_SOURCE_ADVERTISEMENT,
+        )
 
     def test_ignored_provisional_session_does_not_replace_result_face(self) -> None:
         """A menu-only transition cannot attach its face to the last session."""
@@ -869,7 +879,11 @@ class ConnectedSessionDisplayFaceRegressionTests(unittest.TestCase):
         self._notify(c, const.CHAR_SMILEY, b"\x03")
 
         self.assertEqual(c.data["smiley"], "special_3")
+        self.assertEqual(c.data["smiley_source"], const.DATA_SOURCE_DIRECT)
         self.assertEqual(c.data["last_session_display_face"], "special_3")
+        self.assertEqual(
+            c.data["last_session_display_face_source"], const.DATA_SOURCE_DIRECT
+        )
 
     def test_direct_session_without_ff0a_remains_unknown(self) -> None:
         """No notification is a normal unavailable result, not a placeholder."""
@@ -1012,7 +1026,11 @@ class ConnectedSessionDisplayFaceRegressionTests(unittest.TestCase):
         asyncio.run(c._async_apply_charger_passthrough("FF0A", b"\x04"))
 
         self.assertEqual(c.data["smiley"], "special_4")
+        self.assertEqual(c.data["smiley_source"], const.DATA_SOURCE_CHARGER)
         self.assertEqual(c.data["last_session_display_face"], "special_4")
+        self.assertEqual(
+            c.data["last_session_display_face_source"], const.DATA_SOURCE_CHARGER
+        )
 
     def test_charger_forwarded_standard_is_attached_to_completed_session(self) -> None:
         """The iO Sense path must retain raw face 1 as a valid verdict."""
@@ -1452,6 +1470,7 @@ class LastSessionDisplayFaceSensorTests(unittest.IsolatedAsyncioTestCase):
         coordinator_instance.data = {
             "last_session_start": coordinator.dt_util.utcnow(),
             "last_session_display_face": "special_5",
+            "last_session_display_face_source": const.DATA_SOURCE_DIRECT,
         }
         description = next(
             item for item in sensor.SENSORS if item.key == "last_session"
@@ -1468,13 +1487,41 @@ class LastSessionDisplayFaceSensorTests(unittest.IsolatedAsyncioTestCase):
             entity._handle_update(coordinator_instance.data)
 
         self.assertEqual(entity.extra_state_attributes["display_face"], "special_5")
+        self.assertEqual(
+            entity.extra_state_attributes["display_face_source"],
+            const.DATA_SOURCE_DIRECT,
+        )
+
+    def test_smiley_exposes_raw_value_and_transport_source(self) -> None:
+        coordinator_instance, _ = self._entity()
+        coordinator_instance.data.update(
+            {
+                "smiley": "special_7",
+                "smiley_raw": 7,
+                "smiley_source": const.DATA_SOURCE_ADVERTISEMENT,
+            }
+        )
+        description = next(item for item in sensor.SENSORS if item.key == "smiley")
+        entity = sensor.OralBLiveSensor(coordinator_instance, description)
+
+        with patch.object(entity, "async_write_ha_state"):
+            entity._handle_update(coordinator_instance.data)
+
+        self.assertEqual(
+            entity.extra_state_attributes,
+            {"smiley_raw": 7, "source": const.DATA_SOURCE_ADVERTISEMENT},
+        )
 
     async def test_last_session_restores_display_face_after_restart(self) -> None:
         coordinator_instance, entity = self._entity()
         coordinator_instance.data["last_session_display_face"] = None
+        coordinator_instance.data["last_session_display_face_source"] = None
         restored = types.SimpleNamespace(
             state=coordinator_instance.data["last_session_start"].isoformat(),
-            attributes={"display_face": "special_6"},
+            attributes={
+                "display_face": "special_6",
+                "display_face_source": const.DATA_SOURCE_CHARGER,
+            },
         )
         entity.hass = MagicMock()
         entity.async_get_last_state = AsyncMock(return_value=restored)
@@ -1488,7 +1535,15 @@ class LastSessionDisplayFaceSensorTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(
             coordinator_instance.data["last_session_display_face"], "special_6"
         )
+        self.assertEqual(
+            coordinator_instance.data["last_session_display_face_source"],
+            const.DATA_SOURCE_CHARGER,
+        )
         self.assertEqual(entity.extra_state_attributes["display_face"], "special_6")
+        self.assertEqual(
+            entity.extra_state_attributes["display_face_source"],
+            const.DATA_SOURCE_CHARGER,
+        )
 
     async def test_older_restored_face_cannot_fill_newer_session_null(self) -> None:
         """Restore attributes only when their session timestamp also matches."""


### PR DESCRIPTION
## Summary\n\n- expose the raw smiley transport source as a Smiley entity attribute\n- preserve the ending display-face source in Last Session, including restore\n- cover advertisement, direct-brush and charger-bridge provenance with tests\n- document controlled iO 10 hardware validation, including a same-session advertisement versus FF0A comparison\n\nThe hardware run captured a visible ordinary blue smile at 1:51. The advertisement path reported raw 0 / off, while a later direct FF0A read of the unchanged session returned raw 5 / special_5.\n\n## Validation\n\n- 165 tests passed\n- git diff --check passed